### PR TITLE
Add German language

### DIFF
--- a/Language Text/de-DE.json
+++ b/Language Text/de-DE.json
@@ -1,0 +1,180 @@
+{
+  "translation": {
+    "Metazooa": {
+      "species": {
+        "generic": "Rätsel-Tier",
+        "unique": "ein Rätsel-Tier",
+        "indefinite": "ein Rätsel-Tier",
+        "definite": "das Rätsel-Tier",
+        "demonstrative": "dieses"
+      },
+      "answer": "Mensch",
+      "kingdom": {
+        "generic": "Tiere",
+        "concord": "e",
+        "unique": "ein",
+        "definite": "das"
+      },
+      "game": "Metazooa",
+      "mystery": { "singular": "Rätsel", "plural": "Rätsel" },
+      "menagerie": "Zoo"
+    },
+    "Metaflora": {
+      "species": {
+        "generic": "Rätsel-Pflanze",
+        "unique": "eine Rätsel-Pflanze",
+        "indefinite": "eine Rätsel-Pflanze",
+        "definite": "die Rätsel-Pflanze",
+        "demonstrative": "diese"
+      },
+      "answer": "Tomate",
+      "kingdom": {
+        "generic": "Pflanzen",
+        "concord": "en",
+        "unique": "eine",
+        "definite": "die"
+      },
+      "game": "Metaflora",
+      "mystery": { "singular": "Rätsel", "plural": "Rätsel" },
+      "menagerie": "Garten"
+    },
+    "keywords": {
+      "remaining": "verbleibend",
+      "Click": "Klick",
+      "Tap": "Tipp"
+    },
+    "home": {
+      "0": {
+        "0": "Das Reich der Tiere (<i>Metazoa</i>, auf Griechisch) ist voll von unseren entfernten Verwandten... manche sind uns aber näher verwandt als andere. Im Spiel Metazooa kannst Du testen, wie gut Du unseren Stammbaum kennst!",
+	"1": "Der Stammbaum aller Pflanzen (die Wissenschaftler nennen ihn <i>Viridiplantae</i>) ist vielfältig und wunderschön... aber auch ziemlich kompliziert! Im Spiel Metaflora kannst Du dich testen &mdash; hast du einen grünen Daumen, findest Du dich zurecht in seinen vielen Zweigen?"
+      },
+      "1": "Dein Ziel ist: Errate die/das heutige <b>{{species.generic}}</b> mit so wenig Versuchen wie möglich! Mit jedem Versuch kannst du das Ergebnis weiter eingrenzen, denn du siehst, welchen Teil des Stammbaums dein Tipp und das Ergebnis gemeinsam haben. Und je näher du der Lösung kommst (man sagt auch: Je niedriger die gefundene <i>Rangstufe</i>) ist, desto mehr Eigenschaften weißst du über dein/e {{species.generic}}",
+      "2": "Zum Beispiel, sagen wir die Antwort ist “{{answer}}”, und du tippst daneben, dann könnte dein gefundender Stammbaum so aussehen:",
+      "3": "Es gibt nur ein/e {{species.unique}} pro Tag zu finden, aber du hast {{MAX_GUESSES}} dafür! Das nächste Rätsel findest du hier dann ab <b>{{nextGame}}</b>.",
+      "4": "Du hast dein/e {{species.generic}} heute schon gefunden?",
+      "5": "Los gehts!"
+    },
+    "game": {
+      "0": "Tabelle anzeigen",
+      "1": "Deine Antwort und {{guess}} haben diese Abstammung gemeinsam:",
+      "2": "{{click}} hier um mehr zu erfahren",
+      "3": "Gesucht: {{species.generic}}!",
+      "4": "Gewonnen! Herzlichen Glückwunsch! Die Antwort ist <b>{{answer}}</b>"
+    },
+    "modal": {
+      "0": {
+	"0": "Gewonnen!",
+	"1": "Alle Tipps aufgebraucht!"
+      },
+      "2": "Teile deine Punktzahl oder spiele eine Übungsrunde!",
+      "3": "Spiele ein anderes Spiel von"
+    },
+    "share": {
+      "0": "Teilen",
+      "1": "Geteilt!",
+      "2": "Kopiert!",
+      "3": "Fehler; Wir konnten deine Punktzahl nicht teilen!"
+    },
+    "table": {
+      "0": "Rangstufe",
+      "1": "Name",
+      "2": "Versuche",
+      "3": "Tipps",
+      "4": "Zurück zum Stammbaum"
+    },
+    "errors": {
+      "0": "Kein Fehler",
+      "1": "\"{{guess}}\" nicht gefunden in unserer Datenbank",
+      "2": "Du hast \"{{guess}}\" vorher schon mal getippt",
+      "3": "Die Antwort ist \"{{guess}}\"",
+      "4": "Meintest du \"{{guess}}\"?"
+    },
+    "button": {
+      "0": "Auf in den {{menagerie}}!"
+    },
+    "footer": {
+      "0": "by Trainwreck Labs",
+      "1": "Komm auf unseren Discord-Server!",
+      "2": "Hast Du eine Frage?",
+      "3": "Antworten auf häufig gestellte Fragen"
+    },
+    "hint": {
+      "0": "Brauchst du einen Tipp? Tausche 3 Versuche gegen die nächste Rangstufe!",
+      "1": "Tipp"
+    },
+    "wikipedia": {
+      "0": "Aus der Wikipedia",
+      "1": {
+        "Show": "Bild anzeigen",
+        "Hide": "Bild verstecken"
+      }
+    },
+    "guesser": {
+      "0": "Gib irgendeine Art als ersten Rate-Versuch ein!",
+      "1": "Gib hier deinen nächsen Rate-Versuch ein.",
+      "2": "Raten"
+    },
+    "statistics": {
+      "0": "Statistiken",
+      "1": "Spiele",
+      "2": "Lauf",
+      "3": "Runden",
+      "4": "Gewonnen",
+      "5": "Momentan",
+      "6": "Maximum",
+      "7": "Wie viele Versuche du pro Gewinn brauchtest. Die Farbe des Balkens zeigt, wie nah du der korrekten Antwort warst."
+    },
+    "settings": {
+      "0": "Einstellungen",
+      "1": "Wissenschaftliche Namen zum Raten verwenden",
+      "2": "Sprache",
+      "3": "Englisch",
+      "4": "Dunkler Hintergrund"
+    },
+    "practice": {
+      "0": "Übungsrunde",
+      "1": "Spiele so viele Runden {{game}} wie du willst!",
+      "2": "Neue Übungsrunde",
+      "3": "Übungsrunde fortsetzen"
+    },
+    "links": {
+      "0": "Links",
+      "1": "Häufig gestellte Fragen",
+      "2": "Datenschutz"
+    },
+    "twl": {
+      "0": "Konto",
+      "1": "<b>{{game}}</b> mit deinem TWL-Konto verbinden",
+      "2": "Mit Google anmelden",
+      "3": "Mit Discord anmelden",
+      "4": "Den Trainwreck Labs-Newsletter abbonieren",
+      "5": "Werbung entfernen",
+      "6": "Verbindung trennen",
+      "7": "Club-Mitglied"
+    },
+    "faq": {
+      "0": "Häufig gestellte Fragen",
+      "1": {
+        "q": "Wie habt ihr die {{kingdom.generic}} für das Spiel ausgewählt?",
+        "a": "Wir haben {{kingdom.generic}} für {{game}} ausgewählt, die viele Leute kennen. Außerdem haben wir versucht, eine große Vielfalt an Arten mit hineinzunehmen, um das Spiel möglichst interessant zu machen."
+      },
+      "2": {
+        "q": "Im Spiel steht es falsch! In der Wikipedia finde ich andere Einordnungen für eins der {{kingdom.generic}}!",
+	"a": "Das kann schon sein. Die Einordnungen im Spiel basieren auf der <i>NCBI taxonomy</i>. Sie ist die Taxonomie (Einordung der Arten), die für Tiere am häufigsten verwendet wird. Allerdings ist das nicht die einzige Taxonomie. Die Taxonomie von Wikipedia wird auch häufig verwendet, und es kann passieren dass es zwischen den beiden Unterschiede gibt."
+      },
+      "3": {
+        "q": "Warum finde ich die Klasse der \"Reptilien\" oder \"Reptilia\" nicht im Spiel?",
+        "a": "In manchen Taxonomien, beispielsweise in der Wikipedia, findet man die Klasse \"Reptilia\". Die <i>NCBI taxonomy</i> verwendet sie nicht. Stattdessen. Stattdessen wird in der <i>NCBI taxonomy</i> die Klasse \"Sauropsida\" verwendet, die alle Reptilien und Vögel beinhaltet. Der Grund ist, dass manche der Tiere, die man landläufig als \"Reptilien\" bezeichnet, in Wirklichkeit mehr mit den Vögeln als mit anderen Reptilien zu tun haben. Zum Beispiel das Kokodil. Es ist wirklich näher mit den Vögeln als mit den Echsen verwandt!"
+      },
+      "4": {
+        "q": "Why is \"domestic cat\" a possible guess but not \"domestic dog\"?",
+        "q": "Warum kann ich \"Hauskatze\" eintippen, aber nicht \"Haushund\"?",
+        "a": "Die Hauskatzen wurden wissenschaftlich als eine eigene Art eingeteilt (\"Felis catus\"), aber die gezähmten Hunde wurden als eine Unterart des Wolfs eingeteilt. (\"Canis lupus familiaris\")."
+      },
+      "5": {
+        "q": "Gibt es eine Datenschutzerklärung für {{game}}?",
+        "a": "Klicke hier für die <a href=\"/privacy-policy\" class=\"underline\">Datenschutzerklärung von {{game}}</a>."
+      }
+    }
+  }
+}

--- a/Species Lists/animals.json
+++ b/Species Lists/animals.json
@@ -8,7 +8,8 @@
     "name_fr": "anémone",
     "name_it": "anemone",
     "name_pt": "anêmona",
-    "name_ca": "anèmona"
+    "name_ca": "anèmona",
+    "name_de": "Seeanemone"
   },
   {
     "node": 7022,
@@ -19,7 +20,8 @@
     "name_fr": "phasme",
     "name_it": "insetto stecco",
     "name_pt": "bicho-pau",
-    "name_ca": "insecte pal"
+    "name_ca": "insecte pal",
+    "name_de": "Indische Stabschrecke"
   },
   {
     "node": 7051,
@@ -30,7 +32,8 @@
     "name_fr": "luciole",
     "name_it": "lucciola",
     "name_pt": "vagalume",
-    "name_ca": "cuca de llum"
+    "name_ca": "cuca de llum",
+    "name_de": "Genji-Leuchtkäfer"
   },
   {
     "node": 7091,
@@ -41,7 +44,8 @@
     "name_fr": "ver à soie",
     "name_it": "",
     "name_pt": "bicho-da-seda",
-    "name_ca": "cuc de seda"
+    "name_ca": "cuc de seda",
+    "name_de": "Seidenspinner"
   },
   {
     "node": 7159,
@@ -52,7 +56,8 @@
     "name_fr": "moustique",
     "name_it": "zanzara",
     "name_pt": "mosquito",
-    "name_ca": "mosquit"
+    "name_ca": "mosquit",
+    "name_de": "Ägyptische Tigermücke"
   },
   {
     "node": 7227,
@@ -63,7 +68,8 @@
     "name_fr": "drosophile",
     "name_it": "moscerino della frutta",
     "name_pt": "mosca da fruta",
-    "name_ca": "mosca de la fruita"
+    "name_ca": "mosca de la fruita",
+    "name_de": "Fruchtfliege"
   },
   {
     "node": 7370,
@@ -74,7 +80,8 @@
     "name_fr": "mouche",
     "name_it": "mosca domestica",
     "name_pt": "mosca doméstica",
-    "name_ca": "mosca domèstica"
+    "name_ca": "mosca domèstica",
+    "name_de": "Stubenfliege"
   },
   {
     "node": 7445,
@@ -85,7 +92,8 @@
     "name_fr": "frelon",
     "name_it": "calabrone",
     "name_pt": "vespa",
-    "name_ca": "vespa"
+    "name_ca": "vespa",
+    "name_de": "Hornisse"
   },
   {
     "node": 7460,
@@ -96,7 +104,8 @@
     "name_fr": "abeille",
     "name_it": "ape del miele",
     "name_pt": "abelha",
-    "name_ca": "abella de la mel"
+    "name_ca": "abella de la mel",
+    "name_de": "Honigbiene"
   },
   {
     "node": 7604,
@@ -107,7 +116,8 @@
     "name_fr": "étoile de mer",
     "name_it": "stella marina",
     "name_pt": "estrela do mar",
-    "name_ca": "estrella de mar"
+    "name_ca": "estrella de mar",
+    "name_de": "Seestern"
   },
   {
     "node": 7957,
@@ -118,7 +128,8 @@
     "name_fr": "poisson rouge",
     "name_it": "pesce rosso",
     "name_pt": "peixe dourado",
-    "name_ca": "carpí daurat"
+    "name_ca": "carpí daurat",
+    "name_de": "Goldfisch"
   },
   {
     "node": 7962,
@@ -129,7 +140,8 @@
     "name_fr": "carpe",
     "name_it": "carpa",
     "name_pt": "carpa",
-    "name_ca": "carpa"
+    "name_ca": "carpa",
+    "name_de": "Karpfen"
   },
   {
     "node": 7998,
@@ -140,7 +152,8 @@
     "name_fr": "poisson-chat",
     "name_it": "pesce gatto",
     "name_pt": "bagre",
-    "name_ca": "peix gat"
+    "name_ca": "peix gat",
+    "name_de": "Katzenwels"
   },
   {
     "node": 8022,
@@ -151,7 +164,8 @@
     "name_fr": "truite",
     "name_it": "trota",
     "name_pt": "truta",
-    "name_ca": "truita"
+    "name_ca": "truita",
+    "name_de": "Regenbogenforelle"
   },
   {
     "node": 8030,
@@ -162,7 +176,8 @@
     "name_fr": "saumon",
     "name_it": "salmone",
     "name_pt": "salmão",
-    "name_ca": "salmó"
+    "name_ca": "salmó",
+    "name_de": "Lachs"
   },
   {
     "node": 8049,
@@ -173,7 +188,8 @@
     "name_fr": "morue",
     "name_it": "merluzzo",
     "name_pt": "bacalhau",
-    "name_ca": "bacallà"
+    "name_ca": "bacallà",
+    "name_de": "Kabeljau"
   },
   {
     "node": 8245,
@@ -184,7 +200,8 @@
     "name_fr": "espadon",
     "name_it": "pesce spada",
     "name_pt": "peixe espada",
-    "name_ca": "peix espasa"
+    "name_ca": "peix espasa",
+    "name_de": "Schwertfisch"
   },
   {
     "node": 8296,
@@ -195,7 +212,8 @@
     "name_fr": "axolotl",
     "name_it": "axolotl",
     "name_pt": "axolote",
-    "name_ca": "axolot"
+    "name_ca": "axolot",
+    "name_de": "Axolotl"
   },
   {
     "node": 8384,
@@ -206,7 +224,8 @@
     "name_fr": "crapaud",
     "name_it": "rospo",
     "name_pt": "sapo",
-    "name_ca": "gripau"
+    "name_ca": "gripau",
+    "name_de": "Kröte"
   },
   {
     "node": 8400,
@@ -217,7 +236,8 @@
     "name_fr": "grenouille-taureau",
     "name_it": "rana toro americana",
     "name_pt": "sapo-boi",
-    "name_ca": "granota toro"
+    "name_ca": "granota toro",
+    "name_de": "Ochsenfrosch"
   },
   {
     "node": 8496,
@@ -228,7 +248,8 @@
     "name_fr": "alligator",
     "name_it": "alligatore",
     "name_pt": "jacaré",
-    "name_ca": "al·ligàtor"
+    "name_ca": "al·ligàtor",
+    "name_de": "Alligator"
   },
   {
     "node": 8502,
@@ -239,7 +260,8 @@
     "name_fr": "crocodile",
     "name_it": "coccodrillo",
     "name_pt": "cocodilo",
-    "name_ca": "cocodril"
+    "name_ca": "cocodril",
+    "name_de": "Krokodil"
   },
   {
     "node": 8688,
@@ -250,7 +272,8 @@
     "name_fr": "serpent marin",
     "name_it": "serpente di mare",
     "name_pt": "serpente marinha",
-    "name_ca": "serp de mar"
+    "name_ca": "serp de mar",
+    "name_de": "Seeschlange"
   },
   {
     "node": 8790,
@@ -261,7 +284,8 @@
     "name_fr": "émeu",
     "name_it": "emù",
     "name_pt": "emu",
-    "name_ca": "emú"
+    "name_ca": "emú",
+    "name_de": "Emu"
   },
   {
     "node": 8801,
@@ -272,7 +296,8 @@
     "name_fr": "autruche",
     "name_it": "struzzo",
     "name_pt": "avestruz",
-    "name_ca": "estruç"
+    "name_ca": "estruç",
+    "name_de": "Strauß"
   },
   {
     "node": 8853,
@@ -283,7 +308,8 @@
     "name_fr": "oie",
     "name_it": "oca canadese",
     "name_pt": "ganso",
-    "name_ca": "oca del canadà"
+    "name_ca": "oca del canadà",
+    "name_de": "Gans"
   },
   {
     "node": 8869,
@@ -294,7 +320,8 @@
     "name_fr": "cygne",
     "name_it": "cigno",
     "name_pt": "cisne",
-    "name_ca": "cigne"
+    "name_ca": "cigne",
+    "name_de": "Schwan"
   },
   {
     "node": 8954,
@@ -305,7 +332,8 @@
     "name_fr": "faucon",
     "name_it": "falco pellegrino",
     "name_pt": "falcão",
-    "name_ca": "falcó"
+    "name_ca": "falcó",
+    "name_de": "Wanderfalke"
   },
   {
     "node": 33614,
@@ -316,7 +344,8 @@
     "name_fr": "vautour moine",
     "name_it": "urubù",
     "name_pt": "urubu",
-    "name_ca": "voltor"
+    "name_ca": "voltor",
+    "name_de": "Schwarzer Geier"
   },
   {
     "node": 9031,
@@ -327,7 +356,8 @@
     "name_fr": "coq doré",
     "name_it": "gallina",
     "name_pt": "galinha",
-    "name_ca": "gallina"
+    "name_ca": "gallina",
+    "name_de": "Huhn"
   },
   {
     "node": 9042,
@@ -338,7 +368,8 @@
     "name_fr": "faisan",
     "name_it": "fagiano",
     "name_pt": "faisão",
-    "name_ca": "faisà"
+    "name_ca": "faisà",
+    "name_de": "Fasan"
   },
   {
     "node": 34924,
@@ -349,7 +380,8 @@
     "name_fr": "pie",
     "name_it": "gazza ladra",
     "name_pt": "Pega",
-    "name_ca": "garsa"
+    "name_ca": "garsa",
+    "name_de": "Elster"
   },
   {
     "node": 9187,
@@ -360,7 +392,8 @@
     "name_fr": "merle",
     "name_it": "merlo",
     "name_pt": "melro",
-    "name_ca": "merla"
+    "name_ca": "merla",
+    "name_de": "Amsel"
   },
   {
     "node": 9233,
@@ -371,7 +404,8 @@
     "name_fr": "manchot empereur",
     "name_it": "pinguino imperatore",
     "name_pt": "pinguim imperador",
-    "name_ca": "pingüí emperador"
+    "name_ca": "pingüí emperador",
+    "name_de": "Kaiserpinguin"
   },
   {
     "node": 9258,
@@ -382,7 +416,8 @@
     "name_fr": "ornithorynque",
     "name_it": "ornitorinco",
     "name_pt": "ornitorrinco",
-    "name_ca": "ornitorrinc"
+    "name_ca": "ornitorrinc",
+    "name_de": "Schnabeltier"
   },
   {
     "node": 9261,
@@ -393,7 +428,8 @@
     "name_fr": "échidné",
     "name_it": "echidna",
     "name_pt": "equidna",
-    "name_ca": "equidna"
+    "name_ca": "equidna",
+    "name_de": "Ameisenigel"
   },
   {
     "node": 9365,
@@ -404,7 +440,8 @@
     "name_fr": "hérisson",
     "name_it": "riccio",
     "name_pt": "ouriço",
-    "name_ca": "eriçó"
+    "name_ca": "eriçó",
+    "name_de": "Igel"
   },
   {
     "node": 9430,
@@ -415,7 +452,8 @@
     "name_fr": "vampire",
     "name_it": "pipistrello vampiro",
     "name_pt": "morcego-vampiro",
-    "name_ca": "ratpenat vampir"
+    "name_ca": "ratpenat vampir",
+    "name_de": "Vampirfledermaus"
   },
   {
     "node": 9542,
@@ -426,7 +464,8 @@
     "name_fr": "macaque",
     "name_it": "macaco",
     "name_pt": "macaco",
-    "name_ca": "macaco"
+    "name_ca": "macaco",
+    "name_de": "Makak"
   },
   {
     "node": 9561,
@@ -437,7 +476,8 @@
     "name_fr": "mandrill",
     "name_it": "mandrillo",
     "name_pt": "mandril",
-    "name_ca": "mandril"
+    "name_ca": "mandril",
+    "name_de": "Mandrill"
   },
   {
     "node": 9593,
@@ -448,7 +488,8 @@
     "name_fr": "gorille",
     "name_it": "gorilla",
     "name_pt": "gorila",
-    "name_ca": "goril·la"
+    "name_ca": "goril·la",
+    "name_de": "Gorilla"
   },
   {
     "node": 9597,
@@ -459,7 +500,8 @@
     "name_fr": "bonobo",
     "name_it": "bonobo",
     "name_pt": "bonobo",
-    "name_ca": "bonobo"
+    "name_ca": "bonobo",
+    "name_de": "Bonobo"
   },
   {
     "node": 9598,
@@ -470,7 +512,8 @@
     "name_fr": "chimpanzé",
     "name_it": "scimpanzè",
     "name_pt": "chimpanzé",
-    "name_ca": "ximpanzé"
+    "name_ca": "ximpanzé",
+    "name_de": "Schimpanse"
   },
   {
     "node": 9601,
@@ -481,7 +524,8 @@
     "name_fr": "orang-outan",
     "name_it": "orangotango",
     "name_pt": "orangotango",
-    "name_ca": "orangutan"
+    "name_ca": "orangutan",
+    "name_de": "Orang-Utan"
   },
   {
     "node": 9614,
@@ -492,7 +536,8 @@
     "name_fr": "coyote",
     "name_it": "coyote",
     "name_pt": "coiote",
-    "name_ca": "coiot"
+    "name_ca": "coiot",
+    "name_de": "Kojote"
   },
   {
     "node": 9627,
@@ -503,7 +548,8 @@
     "name_fr": "renard roux",
     "name_it": "volpe",
     "name_pt": "raposa vermelha",
-    "name_ca": "guineu"
+    "name_ca": "guineu",
+    "name_de": "Rotfuchs"
   },
   {
     "node": 9643,
@@ -514,7 +560,8 @@
     "name_fr": "ours noir",
     "name_it": "orso nero",
     "name_pt": "urso negro",
-    "name_ca": "os negre"
+    "name_ca": "os negre",
+    "name_de": "Schwarzbär"
   },
   {
     "node": 9644,
@@ -525,7 +572,8 @@
     "name_fr": "ours brun",
     "name_it": "orso bruno",
     "name_pt": "urso marrom",
-    "name_ca": "os marró"
+    "name_ca": "os marró",
+    "name_de": "Braunbär"
   },
   {
     "node": 9646,
@@ -536,7 +584,8 @@
     "name_fr": "panda géant",
     "name_it": "panda gigante",
     "name_pt": "panda gigante",
-    "name_ca": "panda gegant"
+    "name_ca": "panda gegant",
+    "name_de": "Großer Panda"
   },
   {
     "node": 9649,
@@ -547,7 +596,8 @@
     "name_fr": "panda roux",
     "name_it": "panda rosso",
     "name_pt": "panda vermelho",
-    "name_ca": "panda vermell"
+    "name_ca": "panda vermell",
+    "name_de": "Roter Panda"
   },
   {
     "node": 9654,
@@ -558,7 +608,8 @@
     "name_fr": "raton-laveur",
     "name_it": "procione",
     "name_pt": "guaxinim",
-    "name_ca": "os rentador"
+    "name_ca": "os rentador",
+    "name_de": "Waschbär"
   },
   {
     "node": 9666,
@@ -569,7 +620,8 @@
     "name_fr": "vison",
     "name_it": "visone",
     "name_pt": "doninha-europeia",
-    "name_ca": "visó europeu"
+    "name_ca": "visó europeu",
+    "name_de": "Europäischer Nerz"
   },
   {
     "node": 9678,
@@ -580,7 +632,8 @@
     "name_fr": "hyène",
     "name_it": "iena",
     "name_pt": "hiena",
-    "name_ca": "hiena"
+    "name_ca": "hiena",
+    "name_de": "Hyäne"
   },
   {
     "node": 9689,
@@ -591,7 +644,8 @@
     "name_fr": "lion",
     "name_it": "leone",
     "name_pt": "leão",
-    "name_ca": "lleó"
+    "name_ca": "lleó",
+    "name_de": "Löwe"
   },
   {
     "node": 9690,
@@ -602,7 +656,8 @@
     "name_fr": "jaguar",
     "name_it": "giaguaro",
     "name_pt": "onça",
-    "name_ca": "jaguar"
+    "name_ca": "jaguar",
+    "name_de": "Jaguar"
   },
   {
     "node": 9691,
@@ -613,7 +668,8 @@
     "name_fr": "léopard",
     "name_it": "leopardo",
     "name_pt": "leopardo",
-    "name_ca": "leopard"
+    "name_ca": "leopard",
+    "name_de": "Leopard"
   },
   {
     "node": 9694,
@@ -624,7 +680,8 @@
     "name_fr": "tigre",
     "name_it": "tigre",
     "name_pt": "tigre",
-    "name_ca": "tigre"
+    "name_ca": "tigre",
+    "name_de": "Tiger"
   },
   {
     "node": 9696,
@@ -635,7 +692,8 @@
     "name_fr": "puma",
     "name_it": "puma",
     "name_pt": "puma",
-    "name_ca": "puma"
+    "name_ca": "puma",
+    "name_de": "Puma"
   },
   {
     "node": 9704,
@@ -646,7 +704,8 @@
     "name_fr": "otarie",
     "name_it": "leone marino",
     "name_pt": "leão marinho",
-    "name_ca": "lleó marí"
+    "name_ca": "lleó marí",
+    "name_de": "Seelöwe"
   },
   {
     "node": 9707,
@@ -657,7 +716,8 @@
     "name_fr": "morse",
     "name_it": "tricheco",
     "name_pt": "morsa",
-    "name_ca": "morsa"
+    "name_ca": "morsa",
+    "name_de": "Walross"
   },
   {
     "node": 9711,
@@ -668,7 +728,8 @@
     "name_fr": "phoque",
     "name_it": "foca",
     "name_pt": "foca",
-    "name_ca": "foca"
+    "name_ca": "foca",
+    "name_de": "Kegelrobbe"
   },
   {
     "node": 9749,
@@ -679,7 +740,8 @@
     "name_fr": "béluga",
     "name_it": "beluga",
     "name_pt": "beluga",
-    "name_ca": "beluga"
+    "name_ca": "beluga",
+    "name_de": "Belugawal"
   },
   {
     "node": 9755,
@@ -690,7 +752,8 @@
     "name_fr": "cachalot",
     "name_it": "capodoglio",
     "name_pt": "cachalote",
-    "name_ca": "catxalot"
+    "name_ca": "catxalot",
+    "name_de": "Pottwal"
   },
   {
     "node": 9773,
@@ -701,7 +764,8 @@
     "name_fr": "baleine à bosse",
     "name_it": "megattera",
     "name_pt": "baleia jubarte",
-    "name_ca": "iubarta"
+    "name_ca": "iubarta",
+    "name_de": "Buckelwal"
   },
   {
     "node": 9778,
@@ -712,7 +776,8 @@
     "name_fr": "lamantin",
     "name_it": "lamantino",
     "name_pt": "peixe boi",
-    "name_ca": "manatí"
+    "name_ca": "manatí",
+    "name_de": "Seekuh"
   },
   {
     "node": 9785,
@@ -723,7 +788,8 @@
     "name_fr": "éléphant",
     "name_it": "elefante",
     "name_pt": "elefante",
-    "name_ca": "elefant"
+    "name_ca": "elefant",
+    "name_de": "Afrikanischer Elefant"
   },
   {
     "node": 9796,
@@ -734,7 +800,8 @@
     "name_fr": "cheval",
     "name_it": "cavallo",
     "name_pt": "cavalo",
-    "name_ca": "cavall"
+    "name_ca": "cavall",
+    "name_de": "Pferd"
   },
   {
     "node": 9807,
@@ -745,7 +812,8 @@
     "name_fr": "rhinocéros",
     "name_it": "rinoceronte",
     "name_pt": "rinoceronte",
-    "name_ca": "rinoceront"
+    "name_ca": "rinoceront",
+    "name_de": "Nashorn"
   },
   {
     "node": 9818,
@@ -756,7 +824,8 @@
     "name_fr": "oryctérope",
     "name_it": "oritteropo",
     "name_pt": "porco-formigueiro",
-    "name_ca": "porc formiguer"
+    "name_ca": "porc formiguer",
+    "name_de": "Erdferkel"
   },
   {
     "node": 9838,
@@ -767,7 +836,8 @@
     "name_fr": "dromadaire",
     "name_it": "dromedario",
     "name_pt": "camelo",
-    "name_ca": "camell"
+    "name_ca": "camell",
+    "name_de": "Dromedar"
   },
   {
     "node": 9894,
@@ -778,7 +848,8 @@
     "name_fr": "girafe",
     "name_it": "giraffa",
     "name_pt": "girafa",
-    "name_ca": "girafa"
+    "name_ca": "girafa",
+    "name_de": "Giraffe"
   },
   {
     "node": 9901,
@@ -789,7 +860,8 @@
     "name_fr": "bison",
     "name_it": "bisonte",
     "name_pt": "bisão",
-    "name_ca": "bisó"
+    "name_ca": "bisó",
+    "name_de": "Bison"
   },
   {
     "node": 9913,
@@ -800,7 +872,8 @@
     "name_fr": "vache",
     "name_it": "mucca",
     "name_pt": "gado",
-    "name_ca": "bou"
+    "name_ca": "bou",
+    "name_de": "Rind"
   },
   {
     "node": 9940,
@@ -811,7 +884,8 @@
     "name_fr": "mouton",
     "name_it": "pecora",
     "name_pt": "ovelha",
-    "name_ca": "ovella"
+    "name_ca": "ovella",
+    "name_de": "Schaf"
   },
   {
     "node": 9974,
@@ -822,7 +896,8 @@
     "name_fr": "pangolin",
     "name_it": "pangolino",
     "name_pt": "pangolim",
-    "name_ca": "pangolí"
+    "name_ca": "pangolí",
+    "name_de": "Malaiisches Schuppentier (Pangolin)"
   },
   {
     "node": 10036,
@@ -833,7 +908,8 @@
     "name_fr": "hamster",
     "name_it": "criceto",
     "name_pt": "hamster",
-    "name_ca": "hàmster"
+    "name_ca": "hàmster",
+    "name_de": "Goldhamster"
   },
   {
     "node": 10047,
@@ -844,7 +920,8 @@
     "name_fr": "gerbille",
     "name_it": "gerbillo",
     "name_pt": "gerbil",
-    "name_ca": "jerbú"
+    "name_ca": "jerbú",
+    "name_de": "Wüstenrennmaus"
   },
   {
     "node": 10090,
@@ -855,7 +932,8 @@
     "name_fr": "souris",
     "name_it": "topo",
     "name_pt": "camundongo",
-    "name_ca": "ratolí"
+    "name_ca": "ratolí",
+    "name_de": "Hausmaus"
   },
   {
     "node": 10138,
@@ -866,7 +944,8 @@
     "name_fr": "porc-épic",
     "name_it": "istrice",
     "name_pt": "porco espinho",
-    "name_ca": "porc espí"
+    "name_ca": "porc espí",
+    "name_de": "Stachelschwein"
   },
   {
     "node": 12983,
@@ -877,7 +956,8 @@
     "name_fr": "cacatoès",
     "name_it": "cacatua",
     "name_pt": "cacatua",
-    "name_ca": "cacatua de les tanimbar"
+    "name_ca": "cacatua de les tanimbar",
+    "name_de": "Kakadu"
   },
   {
     "node": 13037,
@@ -888,7 +968,8 @@
     "name_fr": "monarque",
     "name_it": "farfalla monarca",
     "name_pt": "borboleta monarca",
-    "name_ca": "papallona monarca"
+    "name_ca": "papallona monarca",
+    "name_de": "Monarchfalter"
   },
   {
     "node": 13125,
@@ -899,7 +980,8 @@
     "name_fr": "lynx commun",
     "name_it": "lince europea",
     "name_pt": "lince",
-    "name_ca": "linx nòrdic"
+    "name_ca": "linx nòrdic",
+    "name_de": "Luchs"
   },
   {
     "node": 13180,
@@ -910,7 +992,8 @@
     "name_fr": "calopsitte",
     "name_it": "calopsita",
     "name_pt": "calopsita",
-    "name_ca": "cacatua nimfa"
+    "name_ca": "cacatua nimfa",
+    "name_de": "Nymphensittich"
   },
   {
     "node": 13397,
@@ -921,7 +1004,8 @@
     "name_fr": "grand requin blanc",
     "name_it": "squalo bianco",
     "name_pt": "tubarão branco",
-    "name_ca": "tauró blanc"
+    "name_ca": "tauró blanc",
+    "name_de": "Weißer Hai"
   },
   {
     "node": 13686,
@@ -932,7 +1016,8 @@
     "name_fr": "fourmi de feu",
     "name_it": "formica di fuoco",
     "name_pt": "formiga de fogo",
-    "name_ca": "formiga de foc"
+    "name_ca": "formiga de foc",
+    "name_de": "Feuerameise"
   },
   {
     "node": 27675,
@@ -943,7 +1028,8 @@
     "name_fr": "paresseux à deux doigts",
     "name_it": "bradipo didattilo",
     "name_pt": "preguiça-real",
-    "name_ca": "peresós"
+    "name_ca": "peresós",
+    "name_de": "Zweifingerfaultier"
   },
   {
     "node": 27794,
@@ -954,7 +1040,8 @@
     "name_fr": "tortue luth",
     "name_it": "tartaruga liuto",
     "name_pt": "tartaruga de couro",
-    "name_ca": "tortuga llaüt"
+    "name_ca": "tortuga llaüt",
+    "name_de": "Lederschildkröte"
   },
   {
     "node": 28701,
@@ -965,7 +1052,8 @@
     "name_fr": "macareux",
     "name_it": "pulcinella di mare",
     "name_pt": "fradinho",
-    "name_ca": "fraret"
+    "name_ca": "fraret",
+    "name_de": "Papageitaucher"
   },
   {
     "node": 28727,
@@ -976,7 +1064,8 @@
     "name_fr": "geai bleu",
     "name_it": "ghiandaia azzurra",
     "name_pt": "gaio-azul",
-    "name_ca": "gaig nord-americà"
+    "name_ca": "gaig nord-americà",
+    "name_de": "Blauhäher"
   },
   {
     "node": 29073,
@@ -987,7 +1076,8 @@
     "name_fr": "ours blanc",
     "name_it": "orso polare",
     "name_pt": "urso polar",
-    "name_ca": "os polar"
+    "name_ca": "os polar",
+    "name_de": "Eisbär"
   },
   {
     "node": 29139,
@@ -998,7 +1088,8 @@
     "name_fr": "wombat",
     "name_it": "vombato",
     "name_pt": "vombate",
-    "name_ca": "uombat"
+    "name_ca": "uombat",
+    "name_de": "Wombat"
   },
   {
     "node": 29159,
@@ -1009,7 +1100,8 @@
     "name_fr": "huître",
     "name_it": "ostrica",
     "name_pt": "ostra",
-    "name_ca": "ostra"
+    "name_ca": "ostra",
+    "name_de": "Auster"
   },
   {
     "node": 30213,
@@ -1020,7 +1112,8 @@
     "name_fr": "guêpe",
     "name_it": "vespa",
     "name_pt": "vespa",
-    "name_ca": "vespa"
+    "name_ca": "vespa",
+    "name_de": "Wespe"
   },
   {
     "node": 30538,
@@ -1031,7 +1124,8 @@
     "name_fr": "alpaga",
     "name_it": "alpaca",
     "name_pt": "alpaca",
-    "name_ca": "alpaca"
+    "name_ca": "alpaca",
+    "name_de": "Alpaka"
   },
   {
     "node": 30548,
@@ -1042,7 +1136,8 @@
     "name_fr": "moufette",
     "name_it": "moffetta",
     "name_pt": "gambá",
-    "name_ca": "mofeta"
+    "name_ca": "mofeta",
+    "name_de": "Stinktier"
   },
   {
     "node": 30554,
@@ -1053,7 +1148,8 @@
     "name_fr": "blaireau",
     "name_it": "tasso",
     "name_pt": "texugo",
-    "name_ca": "teixó"
+    "name_ca": "teixó",
+    "name_de": "Dachs"
   },
   {
     "node": 32536,
@@ -1064,7 +1160,8 @@
     "name_fr": "guépard",
     "name_it": "ghepardo",
     "name_pt": "guepardo",
-    "name_ca": "guepard"
+    "name_ca": "guepard",
+    "name_de": "Gepard"
   },
   {
     "node": 32538,
@@ -1075,7 +1172,8 @@
     "name_fr": "ocelot",
     "name_it": "ocelot",
     "name_pt": "jaguatirica",
-    "name_ca": "ocelot"
+    "name_ca": "ocelot",
+    "name_de": "Ozelot"
   },
   {
     "node": 34882,
@@ -1086,7 +1184,8 @@
     "name_fr": "loutre de mer",
     "name_it": "lontra di mare",
     "name_pt": "lontra-marinha",
-    "name_ca": "llúdriga marina"
+    "name_ca": "llúdriga marina",
+    "name_de": "Seeotter"
   },
   {
     "node": 36312,
@@ -1097,7 +1196,8 @@
     "name_fr": "salamandre",
     "name_it": "salamandra",
     "name_pt": "salamandra",
-    "name_ca": "salamandra"
+    "name_ca": "salamandra",
+    "name_de": "Salamander"
   },
   {
     "node": 37032,
@@ -1108,7 +1208,8 @@
     "name_fr": "suricate",
     "name_it": "suricato",
     "name_pt": "suricato",
-    "name_ca": "suricata"
+    "name_ca": "suricata",
+    "name_de": "Erdmännchen"
   },
   {
     "node": 37189,
@@ -1119,7 +1220,8 @@
     "name_fr": "hippotrague",
     "name_it": "antilope",
     "name_pt": "antílope",
-    "name_ca": "antílop"
+    "name_ca": "antílop",
+    "name_de": "Antilope"
   },
   {
     "node": 37295,
@@ -1130,7 +1232,8 @@
     "name_fr": "capucin",
     "name_it": "scimmia cappuccina",
     "name_pt": "macaco prego",
-    "name_ca": "caputxí"
+    "name_ca": "caputxí",
+    "name_de": "Kapuzineraffe"
   },
   {
     "node": 37610,
@@ -1141,7 +1244,8 @@
     "name_fr": "rouge-gorge",
     "name_it": "pettirosso",
     "name_pt": "tordo",
-    "name_ca": "pit-roig"
+    "name_ca": "pit-roig",
+    "name_de": "Rotkehlchen"
   },
   {
     "node": 37751,
@@ -1152,7 +1256,8 @@
     "name_fr": "gazelle",
     "name_it": "gazzella",
     "name_pt": "gazela",
-    "name_ca": "gasela"
+    "name_ca": "gasela",
+    "name_de": "Gazelle"
   },
   {
     "node": 38626,
@@ -1163,7 +1268,8 @@
     "name_fr": "koala",
     "name_it": "koala",
     "name_pt": "coala",
-    "name_ca": "coala"
+    "name_ca": "coala",
+    "name_de": "Koala"
   },
   {
     "node": 40151,
@@ -1174,7 +1280,8 @@
     "name_fr": "narval",
     "name_it": "narvalo",
     "name_pt": "narval",
-    "name_ca": "narval"
+    "name_ca": "narval",
+    "name_de": "Narwal"
   },
   {
     "node": 42514,
@@ -1185,7 +1292,8 @@
     "name_fr": "piranha",
     "name_it": "piragna",
     "name_pt": "piranha",
-    "name_ca": "piranya"
+    "name_ca": "piranya",
+    "name_de": "Piranha"
   },
   {
     "node": 48849,
@@ -1196,7 +1304,8 @@
     "name_fr": "moineau",
     "name_it": "passerotto",
     "name_pt": "pardal",
-    "name_ca": "pardal"
+    "name_ca": "pardal",
+    "name_de": "Spatz"
   },
   {
     "node": 9375,
@@ -1207,7 +1316,8 @@
     "name_fr": "taupe",
     "name_it": "talpa",
     "name_pt": "toupeira",
-    "name_ca": "talp"
+    "name_ca": "talp",
+    "name_de": "Maulwurf"
   },
   {
     "node": 51338,
@@ -1218,7 +1328,8 @@
     "name_fr": "castor",
     "name_it": "castoro",
     "name_pt": "castor",
-    "name_ca": "castor"
+    "name_ca": "castor",
+    "name_de": "Biber"
   },
   {
     "node": 51908,
@@ -1229,7 +1340,8 @@
     "name_fr": "perruche",
     "name_it": "parrocchetto",
     "name_pt": "periquito",
-    "name_ca": "periquito"
+    "name_ca": "periquito",
+    "name_de": "Sittich"
   },
   {
     "node": 51949,
@@ -1240,7 +1352,8 @@
     "name_fr": "dendrobate",
     "name_it": "raganella velenosa",
     "name_pt": "rã venenosa",
-    "name_ca": "granota arlequí"
+    "name_ca": "granota arlequí",
+    "name_de": "Pfeilgiftfrosch"
   },
   {
     "node": 52644,
@@ -1251,7 +1364,8 @@
     "name_fr": "pygargue",
     "name_it": "aquila calva",
     "name_pt": "águia-careca",
-    "name_ca": "àguila marina"
+    "name_ca": "àguila marina",
+    "name_de": "Weißkopfseeadler"
   },
   {
     "node": 55048,
@@ -1262,7 +1376,8 @@
     "name_fr": "belette",
     "name_it": "donnola",
     "name_pt": "doninha",
-    "name_ca": "mostela"
+    "name_ca": "mostela",
+    "name_de": "Wiesel"
   },
   {
     "node": 56313,
@@ -1273,7 +1388,8 @@
     "name_fr": "chouette effraie",
     "name_it": "barbagianni",
     "name_pt": "coruja-das-torres",
-    "name_ca": "òliba"
+    "name_ca": "òliba",
+    "name_de": "Schleiereule"
   },
   {
     "node": 56781,
@@ -1284,7 +1400,8 @@
     "name_fr": "grand corbeau",
     "name_it": "corvo imperiale",
     "name_pt": "corvo",
-    "name_ca": "corb"
+    "name_ca": "corb",
+    "name_de": "Rabe"
   },
   {
     "node": 57247,
@@ -1295,7 +1412,8 @@
     "name_fr": "gris du gabon",
     "name_it": "pappagallo cenerino",
     "name_pt": "papagaio-cinzento",
-    "name_ca": "lloro gris"
+    "name_ca": "lloro gris",
+    "name_de": "Graupapagei"
   },
   {
     "node": 60713,
@@ -1306,7 +1424,8 @@
     "name_fr": "moqueur",
     "name_it": "mimo settentrionale",
     "name_pt": "tordo-imitador",
-    "name_ca": "mim políglota"
+    "name_ca": "mim políglota",
+    "name_de": "Spottdrossel"
   },
   {
     "node": 61384,
@@ -1317,7 +1436,8 @@
     "name_fr": "lynx roux",
     "name_it": "lince rossa",
     "name_pt": "lince",
-    "name_ca": "linx roig"
+    "name_ca": "linx roig",
+    "name_de": "Rotluchs"
   },
   {
     "node": 9700,
@@ -1328,7 +1448,8 @@
     "name_fr": "mangouste",
     "name_it": "mangusta",
     "name_pt": "mangusto",
-    "name_ca": "mangosta"
+    "name_ca": "mangosta",
+    "name_de": "Mungo"
   },
   {
     "node": 61853,
@@ -1339,7 +1460,8 @@
     "name_fr": "gibbon",
     "name_it": "gibbone",
     "name_pt": "gibão",
-    "name_ca": "gibó"
+    "name_ca": "gibó",
+    "name_de": "Gibbon"
   },
   {
     "node": 76717,
@@ -1350,7 +1472,8 @@
     "name_fr": "loutre de rivière",
     "name_it": "lontra canadese",
     "name_pt": "lontra norte-mericana",
-    "name_ca": "llúdriga"
+    "name_ca": "llúdriga",
+    "name_de": "Flussotter"
   },
   {
     "node": 79627,
@@ -1361,7 +1484,8 @@
     "name_fr": "gorfou sauteur",
     "name_it": "pinguino dalla fronte dorata",
     "name_pt": "pinguim saltador",
-    "name_ca": "pingüí crestadaurat"
+    "name_ca": "pingüí crestadaurat",
+    "name_de": "Goldschopfpinguin"
   },
   {
     "node": 84074,
@@ -1372,7 +1496,8 @@
     "name_fr": "myrmidon",
     "name_it": "formichiere",
     "name_pt": "tamanduaí",
-    "name_ca": "os formiguer"
+    "name_ca": "os formiguer",
+    "name_de": "Zwergameisenbär"
   },
   {
     "node": 85066,
@@ -1383,7 +1508,8 @@
     "name_fr": "corneille",
     "name_it": "cornacchia",
     "name_pt": "corvo",
-    "name_ca": "corb americà"
+    "name_ca": "corb americà",
+    "name_de": "Krähe"
   },
   {
     "node": 89248,
@@ -1394,7 +1520,8 @@
     "name_fr": "zèbre",
     "name_it": "zebra",
     "name_pt": "zebra",
-    "name_ca": "zebra"
+    "name_ca": "zebra",
+    "name_de": "Zebra"
   },
   {
     "node": 89462,
@@ -1405,7 +1532,8 @@
     "name_fr": "buffle",
     "name_it": "bufalo",
     "name_pt": "búfalo",
-    "name_ca": "búfal"
+    "name_ca": "búfal",
+    "name_de": "Wasserbüffel"
   },
   {
     "node": 30640,
@@ -1416,7 +1544,8 @@
     "name_fr": "écureuil gris",
     "name_it": "scoiattolo grigio",
     "name_pt": "esquilo",
-    "name_ca": "esquirol"
+    "name_ca": "esquirol",
+    "name_de": "Eichhörnchen"
   },
   {
     "node": 254707,
@@ -1427,7 +1556,8 @@
     "name_fr": "écureuil volant",
     "name_it": "scoiattolo volante",
     "name_pt": "esquilo voador",
-    "name_ca": "esquirol volador"
+    "name_ca": "esquirol volador",
+    "name_de": "Gleithörnchen"
   },
   {
     "node": 100937,
@@ -1438,7 +1568,8 @@
     "name_fr": "babouin",
     "name_it": "babbuino",
     "name_pt": "babuíno",
-    "name_ca": "papió"
+    "name_ca": "papió",
+    "name_de": "Pavian"
   },
   {
     "node": 104421,
@@ -1449,7 +1580,8 @@
     "name_fr": "fourmi charpentière",
     "name_it": "formica carpentiere",
     "name_pt": "formiga carpinteira",
-    "name_ca": "formiga fustera"
+    "name_ca": "formiga fustera",
+    "name_de": "Zimmermannsameise"
   },
   {
     "node": 109280,
@@ -1460,7 +1592,8 @@
     "name_fr": "hippocampe",
     "name_it": "cavalluccio marino",
     "name_pt": "cavalo marinho",
-    "name_ca": "cavallet de mar"
+    "name_ca": "cavallet de mar",
+    "name_de": "Seepferdchen"
   },
   {
     "node": 132113,
@@ -1471,7 +1604,8 @@
     "name_fr": "bourdon",
     "name_it": "bombo",
     "name_pt": "mamangava",
-    "name_ca": "borinot"
+    "name_ca": "borinot",
+    "name_de": "Hummel"
   },
   {
     "node": 135631,
@@ -1482,7 +1616,8 @@
     "name_fr": "colombe",
     "name_it": "colomba",
     "name_pt": "pomba",
-    "name_ca": "colom feréstec"
+    "name_ca": "colom feréstec",
+    "name_de": "Taube"
   },
   {
     "node": 158814,
@@ -1493,7 +1628,8 @@
     "name_fr": "tortue boîte",
     "name_it": "testuggine",
     "name_pt": "tartaruga de caixa",
-    "name_ca": "tortuga de caixa"
+    "name_ca": "tortuga de caixa",
+    "name_de": "Dosenschildkröte"
   },
   {
     "node": 161767,
@@ -1504,7 +1640,8 @@
     "name_fr": "poisson-clown",
     "name_it": "pesce pagliaccio",
     "name_pt": "peixe palhaço",
-    "name_ca": "peix pallasso"
+    "name_ca": "peix pallasso",
+    "name_de": "Clownfisch"
   },
   {
     "node": 176946,
@@ -1515,7 +1652,8 @@
     "name_fr": "python birman",
     "name_it": "pitone birmano",
     "name_pt": "píton birmanesa",
-    "name_ca": "pitó de birmania"
+    "name_ca": "pitó de birmania",
+    "name_de": "Birmanische Python"
   },
   {
     "node": 218467,
@@ -1526,7 +1664,8 @@
     "name_fr": "scorpion",
     "name_it": "scorpione",
     "name_pt": "escorpião",
-    "name_ca": "escorpí"
+    "name_ca": "escorpí",
+    "name_de": "Skorpion"
   },
   {
     "node": 37607,
@@ -1537,7 +1676,8 @@
     "name_fr": "bouvreuil",
     "name_it": "ciuffolotto",
     "name_pt": "dom-fafe",
-    "name_ca": "pinsà borroner"
+    "name_ca": "pinsà borroner",
+    "name_de": "Gimpel"
   },
   {
     "node": 262124,
@@ -1548,7 +1688,8 @@
     "name_fr": "pigeon",
     "name_it": "piccione",
     "name_pt": "pomba kereru",
-    "name_ca": "colom"
+    "name_ca": "colom",
+    "name_de": "Kererū"
   },
   {
     "node": 301843,
@@ -1559,7 +1700,8 @@
     "name_fr": "gecko",
     "name_it": "geco",
     "name_pt": "lagartixa",
-    "name_ca": "dragó"
+    "name_ca": "dragó",
+    "name_de": "Kapgecko"
   },
   {
     "node": 308060,
@@ -1570,7 +1712,8 @@
     "name_fr": "kiwi",
     "name_it": "kiwi",
     "name_pt": "kiwi",
-    "name_ca": "kiwi"
+    "name_ca": "kiwi",
+    "name_de": "Kiwi"
   },
   {
     "node": 340076,
@@ -1581,7 +1724,8 @@
     "name_fr": "tatou",
     "name_it": "armadillo",
     "name_pt": "tatu",
-    "name_ca": "armadillo"
+    "name_ca": "armadillo",
+    "name_de": "Gürteltier"
   },
   {
     "node": 371907,
@@ -1592,7 +1736,8 @@
     "name_fr": "harfang des neiges",
     "name_it": "civetta delle nevi",
     "name_pt": "coruja das neves",
-    "name_ca": "duc blanc"
+    "name_ca": "duc blanc",
+    "name_de": "Schnee-Eule"
   },
   {
     "node": 383689,
@@ -1603,7 +1748,8 @@
     "name_fr": "rossignol",
     "name_it": "usignolo",
     "name_pt": "rouxinol",
-    "name_ca": "rossinyol"
+    "name_ca": "rossinyol",
+    "name_de": "Nachtigall"
   },
   {
     "node": 494514,
@@ -1614,7 +1760,8 @@
     "name_fr": "renard polaire",
     "name_it": "volpe artica",
     "name_pt": "raposa do ártico",
-    "name_ca": "guineu àrtica"
+    "name_ca": "guineu àrtica",
+    "name_de": "Polarfuchs"
   },
   {
     "node": 505845,
@@ -1625,7 +1772,8 @@
     "name_fr": "roussette",
     "name_it": "pipistrello della frutta",
     "name_pt": "morcego da fruta",
-    "name_ca": "guineu voladora"
+    "name_ca": "guineu voladora",
+    "name_de": "Flughund"
   },
   {
     "node": 1037346,
@@ -1636,7 +1784,8 @@
     "name_fr": "épervier",
     "name_it": "sparviere",
     "name_pt": "gavião",
-    "name_ca": "astor"
+    "name_ca": "astor",
+    "name_de": "Habicht"
   },
   {
     "node": 6610,
@@ -1647,7 +1796,8 @@
     "name_fr": "seiche",
     "name_it": "seppia",
     "name_pt": "sépia",
-    "name_ca": "sèpia"
+    "name_ca": "sèpia",
+    "name_de": "Sepia"
   },
   {
     "node": 102866,
@@ -1658,7 +1808,8 @@
     "name_fr": "poulpe à anneaux bleus",
     "name_it": "polpo dagli anelli blu",
     "name_pt": "polvo de anéis azuis",
-    "name_ca": "pop d'anelles blaves"
+    "name_ca": "pop d'anelles blaves",
+    "name_de": "Blauring-Krake"
   },
   {
     "node": 256136,
@@ -1669,7 +1820,8 @@
     "name_fr": "calmar géant",
     "name_it": "calamaro gigante",
     "name_pt": "lula gigante",
-    "name_ca": "calamar gegant"
+    "name_ca": "calamar gegant",
+    "name_de": "Riesenkalmar"
   },
   {
     "node": 260533,
@@ -1680,7 +1832,8 @@
     "name_fr": "mygale",
     "name_it": "tarantola golia",
     "name_pt": "tarântula",
-    "name_ca": "taràntula"
+    "name_ca": "taràntula",
+    "name_de": "Riesenvogelspinne"
   },
   {
     "node": 679132,
@@ -1691,7 +1844,8 @@
     "name_fr": "araignée-chasseuse des forêts",
     "name_it": "ragno cacciatore gigante",
     "name_pt": "aranha-caçadora-gigante",
-    "name_ca": "aranya caçadora gegant"
+    "name_ca": "aranya caçadora gegant",
+    "name_de": "Riesenkrabbenspinne"
   },
   {
     "node": 6925,
@@ -1702,7 +1856,8 @@
     "name_fr": "veuve noire",
     "name_it": "vedova nera",
     "name_pt": "viúva negra",
-    "name_ca": "vídua negra"
+    "name_ca": "vídua negra",
+    "name_de": "Schwarze Witwe"
   },
   {
     "node": 8517,
@@ -1713,7 +1868,8 @@
     "name_fr": "iguane vert",
     "name_it": "iguana",
     "name_pt": "iguana",
-    "name_ca": "iguana"
+    "name_ca": "iguana",
+    "name_de": "Leguan"
   },
   {
     "node": 91907,
@@ -1724,7 +1880,8 @@
     "name_fr": "caméléon",
     "name_it": "camaleonte",
     "name_pt": "camaleão",
-    "name_ca": "camaleó"
+    "name_ca": "camaleó",
+    "name_de": "Chamäleon"
   },
   {
     "node": 6145,
@@ -1735,7 +1892,8 @@
     "name_fr": "méduse",
     "name_it": "medusa",
     "name_pt": "água-viva",
-    "name_ca": "aurèlia"
+    "name_ca": "aurèlia",
+    "name_de": "Gemeine Ohrenqualle"
   },
   {
     "node": 6584,
@@ -1746,7 +1904,8 @@
     "name_fr": "palourde",
     "name_it": "vongola",
     "name_pt": "molusco do mar",
-    "name_ca": "cloïssa de l'atlàntic"
+    "name_ca": "cloïssa de l'atlàntic",
+    "name_de": "Meerklaffmuschel"
   },
   {
     "node": 6707,
@@ -1757,7 +1916,8 @@
     "name_fr": "homard",
     "name_it": "astice",
     "name_pt": "lagosta",
-    "name_ca": "llamàntol"
+    "name_ca": "llamàntol",
+    "name_de": "Europäischer Hummer"
   },
   {
     "node": 102976,
@@ -1768,7 +1928,8 @@
     "name_fr": "krill",
     "name_it": "krill",
     "name_pt": "krill",
-    "name_ca": "krill"
+    "name_ca": "krill",
+    "name_de": "Pazifischer Krill"
   },
   {
     "node": 6536,
@@ -1779,7 +1940,8 @@
     "name_fr": "escargot",
     "name_it": "chiocciola",
     "name_pt": "escargot",
-    "name_ca": "caragol de borgonya"
+    "name_ca": "caragol de borgonya",
+    "name_de": "Weinbergschnecke"
   },
   {
     "node": 2067768,
@@ -1790,7 +1952,8 @@
     "name_fr": "limace-banane",
     "name_it": "lumaca banana",
     "name_pt": "lesma banana",
-    "name_ca": "llimac plàtan"
+    "name_ca": "llimac plàtan",
+    "name_de": "Bananaschnecke"
   },
   {
     "node": 7671,
@@ -1801,7 +1964,8 @@
     "name_fr": "oursin",
     "name_it": "riccio di mare",
     "name_pt": "ouriço-do-mar",
-    "name_ca": "eriçó de mar"
+    "name_ca": "eriçó de mar",
+    "name_de": "Seeigel"
   },
   {
     "node": 242715,
@@ -1812,7 +1976,8 @@
     "name_fr": "corail-cerveau",
     "name_it": "corallo cervello",
     "name_pt": "coral-cérebro",
-    "name_ca": "corall cervell"
+    "name_ca": "corall cervell",
+    "name_de": "Gehirnkoralle"
   },
   {
     "node": 168775,
@@ -1823,7 +1988,8 @@
     "name_fr": "physalie",
     "name_it": "caravella portoghese",
     "name_pt": "caravela-portuguesa",
-    "name_ca": "caravel·la portuguesa"
+    "name_ca": "caravel·la portuguesa",
+    "name_de": "Portugiesische Galeere"
   },
   {
     "node": 195334,
@@ -1834,7 +2000,8 @@
     "name_fr": "requin-marteau",
     "name_it": "squalo martello",
     "name_pt": "tubarão cabeça de martelo",
-    "name_ca": "tauró martell"
+    "name_ca": "tauró martell",
+    "name_de": "Hammerhai"
   },
   {
     "node": 9833,
@@ -1845,7 +2012,8 @@
     "name_fr": "hippopotame",
     "name_it": "ippopotamo",
     "name_pt": "hipopótamo",
-    "name_ca": "hipopòtam"
+    "name_ca": "hipopòtam",
+    "name_de": "Flusspferd"
   },
   {
     "node": 7507,
@@ -1856,7 +2024,8 @@
     "name_fr": "mante religieuse",
     "name_it": "mantide religiosa",
     "name_pt": "louva-a-deus",
-    "name_ca": "mantis"
+    "name_ca": "mantis",
+    "name_de": "Gottesanbeterin"
   },
   {
     "node": 35669,
@@ -1867,7 +2036,8 @@
     "name_fr": "goéland",
     "name_it": "gabbiano",
     "name_pt": "gaivota",
-    "name_ca": "gavià argentat"
+    "name_ca": "gavià argentat",
+    "name_de": "Silbermöwe"
   },
   {
     "node": 6687,
@@ -1878,7 +2048,8 @@
     "name_fr": "crevette géante tigrée",
     "name_it": "gambero gigante indopacifico",
     "name_pt": "camarão tigre",
-    "name_ca": "llagostí negre"
+    "name_ca": "llagostí negre",
+    "name_de": "Tiger-Garnele"
   },
   {
     "node": 51876,
@@ -1889,7 +2060,8 @@
     "name_fr": "anaconda",
     "name_it": "anaconda",
     "name_pt": "sucuri",
-    "name_ca": "anaconda"
+    "name_ca": "anaconda",
+    "name_de": "Grüne Anakonda"
   },
   {
     "node": 56350,
@@ -1900,7 +2072,8 @@
     "name_fr": "crécerelle",
     "name_it": "gheppio",
     "name_pt": "falcão-americano",
-    "name_ca": "xoriguer"
+    "name_ca": "xoriguer",
+    "name_de": "Amerikanischer Turmfalke"
   },
   {
     "node": 9739,
@@ -1911,7 +2084,8 @@
     "name_fr": "dauphin",
     "name_it": "delfino",
     "name_pt": "golfinho",
-    "name_ca": "dofí"
+    "name_ca": "dofí",
+    "name_de": "Großer Tümmler"
   },
   {
     "node": 166335,
@@ -1922,7 +2096,8 @@
     "name_fr": "bousier",
     "name_it": "scarabeo stercorario",
     "name_pt": "escaravelho",
-    "name_ca": "escarabat"
+    "name_ca": "escarabat",
+    "name_de": "Heiliger Pillendreher"
   },
   {
     "node": 9321,
@@ -1933,7 +2108,8 @@
     "name_fr": "kangourou",
     "name_it": "canguro",
     "name_pt": "canguru",
-    "name_ca": "cangur"
+    "name_ca": "cangur",
+    "name_de": "Rotes Riesenkänguru"
   },
   {
     "node": 95723,
@@ -1944,7 +2120,8 @@
     "name_fr": "toucan",
     "name_it": "tucano",
     "name_pt": "tucano",
-    "name_ca": "tucà"
+    "name_ca": "tucà",
+    "name_de": "Tukan"
   },
   {
     "node": 9844,
@@ -1955,7 +2132,8 @@
     "name_fr": "lama",
     "name_it": "lama",
     "name_pt": "lhama",
-    "name_ca": "llama"
+    "name_ca": "llama",
+    "name_de": "Lama"
   },
   {
     "node": 8924,
@@ -1966,7 +2144,8 @@
     "name_fr": "condor",
     "name_it": "condor",
     "name_pt": "condor",
-    "name_ca": "còndor"
+    "name_ca": "còndor",
+    "name_de": "Andenkondor"
   },
   {
     "node": 435638,
@@ -1977,7 +2156,8 @@
     "name_fr": "flamant",
     "name_it": "fenicottero",
     "name_pt": "flamingo",
-    "name_ca": "flamenc"
+    "name_ca": "flamenc",
+    "name_de": "Rosaflamingo"
   },
   {
     "node": 9995,
@@ -1988,7 +2168,8 @@
     "name_fr": "marmotte",
     "name_it": "marmotta",
     "name_pt": "marmota",
-    "name_ca": "marmota"
+    "name_ca": "marmota",
+    "name_de": "Murmel"
   },
   {
     "node": 8005,
@@ -1999,7 +2180,8 @@
     "name_fr": "anguille électrique",
     "name_it": "anguilla elettrica",
     "name_pt": "enguia elétrica",
-    "name_ca": "anguila elèctrica"
+    "name_ca": "anguila elèctrica",
+    "name_de": "Elektrischer Aal"
   },
   {
     "node": 8624,
@@ -2010,7 +2192,8 @@
     "name_fr": "mamba noir",
     "name_it": "mamba nero",
     "name_pt": "mamba negra",
-    "name_ca": "mamba negra"
+    "name_ca": "mamba negra",
+    "name_de": "Schwarze Mamba"
   },
   {
     "node": 61221,
@@ -2021,7 +2204,8 @@
     "name_fr": "dragon de komodo",
     "name_it": "drago di komodo",
     "name_pt": "dragão de komodo",
-    "name_ca": "dragó de komodo"
+    "name_ca": "dragó de komodo",
+    "name_de": "Komodowaran"
   },
   {
     "node": 9305,
@@ -2032,7 +2216,8 @@
     "name_fr": "diable de tasmanie",
     "name_it": "diavolo della tasmania",
     "name_pt": "diabo da tasmânia",
-    "name_ca": "diable de tasmània"
+    "name_ca": "diable de tasmània",
+    "name_de": "Beutelteufel"
   },
   {
     "node": 9447,
@@ -2043,7 +2228,8 @@
     "name_fr": "lémur",
     "name_it": "lemure",
     "name_pt": "lêmure",
-    "name_ca": "lèmur"
+    "name_ca": "lèmur",
+    "name_de": "Katta"
   },
   {
     "node": 7010,
@@ -2054,7 +2240,8 @@
     "name_fr": "criquet pèlerin",
     "name_it": "locusta",
     "name_pt": "gafanhoto",
-    "name_ca": "llagosta del desert"
+    "name_ca": "llagosta del desert",
+    "name_de": "Wüstenheuschrecke"
   },
   {
     "node": 7009,
@@ -2065,7 +2252,8 @@
     "name_fr": "criquet d'amérique",
     "name_it": "cavalletta",
     "name_pt": "esperança",
-    "name_ca": "llagosta americana"
+    "name_ca": "llagosta americana",
+    "name_de": "Gewöhnliche Grashüpfer"
   },
   {
     "node": 58607,
@@ -2076,7 +2264,8 @@
     "name_fr": "grillon",
     "name_it": "grillo",
     "name_pt": "grilo",
-    "name_ca": "grill"
+    "name_ca": "grill",
+    "name_de": "Heuschrecke"
   },
   {
     "node": 1574408,
@@ -2087,7 +2276,8 @@
     "name_fr": "wapiti",
     "name_it": "wapiti",
     "name_pt": "uapiti",
-    "name_ca": "uapití"
+    "name_ca": "uapití",
+    "name_de": "Wapiti"
   },
   {
     "node": 9870,
@@ -2098,7 +2288,8 @@
     "name_fr": "renne",
     "name_it": "caribù",
     "name_pt": "caribú",
-    "name_ca": "ren"
+    "name_ca": "ren",
+    "name_de": "Rentier"
   },
   {
     "node": 70868,
@@ -2109,7 +2300,8 @@
     "name_fr": "barracuda",
     "name_it": "barracuda",
     "name_pt": "barracuda",
-    "name_ca": "barracuda"
+    "name_ca": "barracuda",
+    "name_de": "Barrakuda"
   },
   {
     "node": 41139,
@@ -2120,7 +2312,8 @@
     "name_fr": "coccinelle",
     "name_it": "coccinella",
     "name_pt": "joaninha",
-    "name_ca": "marieta"
+    "name_ca": "marieta",
+    "name_de": "Siebenpunkt-Marienkäfer"
   },
   {
     "node": 63978,
@@ -2131,7 +2324,8 @@
     "name_fr": "atlas",
     "name_it": "farfalla cobra",
     "name_pt": "mariposa atlas",
-    "name_ca": "papallona atles"
+    "name_ca": "papallona atles",
+    "name_de": "Atlas-Falter"
   },
   {
     "node": 36987,
@@ -2142,7 +2336,8 @@
     "name_fr": "termite",
     "name_it": "termite",
     "name_pt": "cupim",
-    "name_ca": "tèrmit"
+    "name_ca": "tèrmit",
+    "name_de": "Formosanische Termiten"
   },
   {
     "node": 6978,
@@ -2153,7 +2348,8 @@
     "name_fr": "blatte",
     "name_it": "scarafaggio",
     "name_pt": "barata",
-    "name_ca": "panerola"
+    "name_ca": "panerola",
+    "name_de": "Amerikanische Schabe"
   },
   {
     "node": 13068,
@@ -2164,7 +2360,8 @@
     "name_fr": "perce-oreille",
     "name_it": "tagliaforbice",
     "name_pt": "lacrainha",
-    "name_ca": "tisoretes"
+    "name_ca": "tisoretes",
+    "name_de": "Ohrwurm"
   },
   {
     "node": 1646243,
@@ -2175,7 +2372,8 @@
     "name_fr": "libellule",
     "name_it": "libellula",
     "name_pt": "libélula",
-    "name_ca": "libèl·lula"
+    "name_ca": "libèl·lula",
+    "name_de": "Kanadische Mosaikjungfer"
   },
   {
     "node": 8554,
@@ -2186,7 +2384,8 @@
     "name_fr": "monstre de gila",
     "name_it": "mostro di gila",
     "name_pt": "monstro de gila",
-    "name_ca": "monstre de gila"
+    "name_ca": "monstre de gila",
+    "name_de": "Gila-Krustenechse"
   },
   {
     "node": 10149,
@@ -2197,7 +2396,8 @@
     "name_fr": "capybara",
     "name_it": "capibara",
     "name_pt": "capivara",
-    "name_ca": "capibara"
+    "name_ca": "capibara",
+    "name_de": "Wasserschwein"
   },
   {
     "node": 1983395,
@@ -2208,7 +2408,8 @@
     "name_fr": "raie manta",
     "name_it": "manta",
     "name_pt": "raia manta",
-    "name_ca": "manta gegant"
+    "name_ca": "manta gegant",
+    "name_de": "Rochen"
   },
   {
     "node": 2484686,
@@ -2219,7 +2420,8 @@
     "name_fr": "raie pastenague",
     "name_it": "razza",
     "name_pt": "raia do sul",
-    "name_ca": "escurçana americana"
+    "name_ca": "escurçana americana",
+    "name_de": "Stechrochen"
   },
   {
     "node": 1129476,
@@ -2230,7 +2432,8 @@
     "name_fr": "bernard-l'hermite",
     "name_it": "paguro",
     "name_pt": "caranguejo ermitão",
-    "name_ca": "cranc hermità"
+    "name_ca": "cranc hermità",
+    "name_de": "Einsiedlerkrebs"
   },
   {
     "node": 342437,
@@ -2241,7 +2444,8 @@
     "name_fr": "poisson-globe",
     "name_it": "pesce palla",
     "name_pt": "baiacu",
-    "name_ca": "peix globus"
+    "name_ca": "peix globus",
+    "name_de": "Kugelfisch"
   },
   {
     "node": 9049,
@@ -2252,7 +2456,8 @@
     "name_fr": "paon",
     "name_it": "pavone",
     "name_pt": "pavão",
-    "name_ca": "paó"
+    "name_ca": "paó",
+    "name_de": "Pfau"
   },
   {
     "node": 571810,
@@ -2263,7 +2468,8 @@
     "name_fr": "concombre de mer",
     "name_it": "cetriolo di mare",
     "name_pt": "pepino-do-mar",
-    "name_ca": "cogombre de mar"
+    "name_ca": "cogombre de mar",
+    "name_de": "Seegurke"
   },
   {
     "node": 9852,
@@ -2274,7 +2480,8 @@
     "name_fr": "élan",
     "name_it": "alce",
     "name_pt": "alce",
-    "name_ca": "ant"
+    "name_ca": "ant",
+    "name_de": "Elch"
   },
   {
     "node": 13347,
@@ -2285,7 +2492,8 @@
     "name_fr": "cloporte",
     "name_it": "porcellino di terra",
     "name_pt": "tatuzinho-de-jardim",
-    "name_ca": "porquet de sant antoni"
+    "name_ca": "porquet de sant antoni",
+    "name_de": "Kellerassel"
   },
   {
     "node": 110520,
@@ -2296,7 +2504,8 @@
     "name_fr": "balane",
     "name_it": "balano",
     "name_pt": "craca",
-    "name_ca": "percebe"
+    "name_ca": "percebe",
+    "name_de": "Seepocke"
   },
   {
     "node": 8574,
@@ -2307,7 +2516,8 @@
     "name_fr": "boa constricteur",
     "name_it": "boa constritor",
     "name_pt": "jiboia",
-    "name_ca": "boa constrictor"
+    "name_ca": "boa constrictor",
+    "name_de": "Boa Constrictor"
   },
   {
     "node": 30521,
@@ -2318,7 +2528,8 @@
     "name_fr": "yack",
     "name_it": "yak",
     "name_pt": "iaque",
-    "name_ca": "iac"
+    "name_ca": "iac",
+    "name_de": "Yak"
   },
   {
     "node": 10141,
@@ -2329,7 +2540,8 @@
     "name_fr": "cochon d'inde",
     "name_it": "porcellino d'india",
     "name_pt": "porquinho da índia",
-    "name_ca": "conillet d'índies"
+    "name_ca": "conillet d'índies",
+    "name_de": "Meerschweinchen"
   },
   {
     "node": 8697,
@@ -2340,7 +2552,8 @@
     "name_fr": "vipère",
     "name_it": "vipera",
     "name_pt": "víbora chifruda",
-    "name_ca": "escurçó cornut"
+    "name_ca": "escurçó cornut",
+    "name_de": "Wüstensandviper"
   },
   {
     "node": 66189,
@@ -2351,7 +2564,8 @@
     "name_fr": "tortue géante des galápagos",
     "name_it": "tartaruga delle galàpagos",
     "name_pt": "tartaruga de galápagos",
-    "name_ca": "tortuga de les galàpagos"
+    "name_ca": "tortuga de les galàpagos",
+    "name_de": "Riesenschildkröte"
   },
   {
     "node": 8475,
@@ -2362,7 +2576,8 @@
     "name_fr": "tortue serpentine",
     "name_it": "tartaruga azzannatrice",
     "name_pt": "tartaruga mordedora",
-    "name_ca": "tortuga mossegadora"
+    "name_ca": "tortuga mossegadora",
+    "name_de": "Schnappschildkröte"
   },
   {
     "node": 8730,
@@ -2373,7 +2588,8 @@
     "name_fr": "crotale",
     "name_it": "serpente a sonagli",
     "name_pt": "cascavél",
-    "name_ca": "serp de cascabell"
+    "name_ca": "serp de cascabell",
+    "name_de": "Klapperschlange"
   },
   {
     "node": 9268,
@@ -2384,7 +2600,8 @@
     "name_fr": "opossum",
     "name_it": "opossum",
     "name_pt": "gambá-comum",
-    "name_ca": "opòssum"
+    "name_ca": "opòssum",
+    "name_de": "Beutelratte"
   },
   {
     "node": 1247135,
@@ -2395,7 +2612,8 @@
     "name_fr": "scarabée rhinocéros",
     "name_it": "scarabeo ercole",
     "name_pt": "besouro hércules",
-    "name_ca": "escarabat hèrcules"
+    "name_ca": "escarabat hèrcules",
+    "name_de": "Herkuleskäfer"
   },
   {
     "node": 6421,
@@ -2406,7 +2624,8 @@
     "name_fr": "sangsue",
     "name_it": "sanguisuga",
     "name_pt": "sanguessuga",
-    "name_ca": "sangonera"
+    "name_ca": "sangonera",
+    "name_de": "Blutegel"
   },
   {
     "node": 8074,
@@ -2417,7 +2636,8 @@
     "name_fr": "baudroie",
     "name_it": "rana pescatrice",
     "name_pt": "peixe pescador",
-    "name_ca": "rap"
+    "name_ca": "rap",
+    "name_de": "Seeteufel"
   },
   {
     "node": 6398,
@@ -2428,7 +2648,8 @@
     "name_fr": "ver de terre",
     "name_it": "lombrico",
     "name_pt": "minhoca",
-    "name_ca": "cuc de terra"
+    "name_ca": "cuc de terra",
+    "name_de": "Regenwurm"
   },
   {
     "node": 1351942,
@@ -2439,7 +2660,8 @@
     "name_fr": "dollar des sables",
     "name_it": "dollaro della sabbia",
     "name_pt": "bolacha da praia",
-    "name_ca": "dòlar de sorra"
+    "name_ca": "dòlar de sorra",
+    "name_de": "Sanddollar"
   },
   {
     "node": 6550,
@@ -2450,7 +2672,8 @@
     "name_fr": "moule",
     "name_it": "cozza",
     "name_pt": "mexilhão",
-    "name_ca": "musclo"
+    "name_ca": "musclo",
+    "name_de": "Miesmuschel"
   },
   {
     "node": 120888,
@@ -2461,7 +2684,8 @@
     "name_fr": "crevette-mante",
     "name_it": "canocchia pavone",
     "name_pt": "lagosta boxeadora",
-    "name_ca": "gamba mantis"
+    "name_ca": "gamba mantis",
+    "name_de": "Pfeilgrundel"
   },
   {
     "node": 8665,
@@ -2472,7 +2696,8 @@
     "name_fr": "cobra royal",
     "name_it": "cobra",
     "name_pt": "cobra real",
-    "name_ca": "cobra reial"
+    "name_ca": "cobra reial",
+    "name_de": "Königskobra"
   },
   {
     "node": 291247,
@@ -2483,7 +2708,8 @@
     "name_fr": "mille-pattes",
     "name_it": "millepiedi",
     "name_pt": "mil-pés",
-    "name_ca": "milpeus"
+    "name_ca": "milpeus",
+    "name_de": "Tausendfüßler"
   },
   {
     "node": 8081,
@@ -2494,7 +2720,8 @@
     "name_fr": "guppy",
     "name_it": "guppy",
     "name_pt": "barrigudinho",
-    "name_ca": "guppy"
+    "name_ca": "guppy",
+    "name_de": "Guppy"
   },
   {
     "node": 9333,
@@ -2505,7 +2732,8 @@
     "name_fr": "phalanger",
     "name_it": "coda ad anello",
     "name_pt": "possum",
-    "name_ca": "uta"
+    "name_ca": "uta",
+    "name_de": "Kletterbeutler"
   },
   {
     "node": 1678817,
@@ -2516,7 +2744,8 @@
     "name_fr": "éphémère",
     "name_it": "effimera",
     "name_pt": "efêmero",
-    "name_ca": "efemeròpter"
+    "name_ca": "efemeròpter",
+    "name_de": "Eintagsfliege"
   },
   {
     "node": 29022,
@@ -2527,7 +2756,8 @@
     "name_fr": "scutigère",
     "name_it": "scutigera",
     "name_pt": "centopeia caseira",
-    "name_ca": "centpeus"
+    "name_ca": "centpeus",
+    "name_de": "Hundertfüßer"
   },
   {
     "node": 45474,
@@ -2538,7 +2768,8 @@
     "name_fr": "tamia",
     "name_it": "tamia",
     "name_pt": "tâmia",
-    "name_ca": "esquirol llistat"
+    "name_ca": "esquirol llistat",
+    "name_de": "Streifenhörnchen"
   },
   {
     "node": 8236,
@@ -2549,7 +2780,8 @@
     "name_fr": "thon",
     "name_it": "tonno",
     "name_pt": "atum",
-    "name_ca": "tonyina"
+    "name_ca": "tonyina",
+    "name_de": "Gelbflossen-Thunfisch"
   },
   {
     "node": 190476,
@@ -2560,7 +2792,8 @@
     "name_fr": "caïman",
     "name_it": "caimano",
     "name_pt": "caiman",
-    "name_ca": "caiman"
+    "name_ca": "caiman",
+    "name_de": "Brillenkaiman"
   },
   {
     "node": 68724,
@@ -2571,7 +2804,8 @@
     "name_fr": "chacal",
     "name_it": "sciacallo",
     "name_pt": "chacal",
-    "name_ca": "xacal"
+    "name_ca": "xacal",
+    "name_de": "Goldschakal"
   },
   {
     "node": 7819,
@@ -2582,7 +2816,8 @@
     "name_fr": "requin-tigre",
     "name_it": "squalo tigre",
     "name_pt": "tubarão-tigre",
-    "name_ca": "tauró tigre"
+    "name_ca": "tauró tigre",
+    "name_de": "Tigerhai"
   },
   {
     "node": 57987,
@@ -2593,7 +2828,8 @@
     "name_fr": "requin-lutin",
     "name_it": "squalo goblin",
     "name_pt": "tubarão-duende",
-    "name_ca": "tauró follet"
+    "name_ca": "tauró follet",
+    "name_de": "Koboldhai"
   },
   {
     "node": 267067,
@@ -2604,7 +2840,8 @@
     "name_fr": "pieuvre géante",
     "name_it": "piovra gigante",
     "name_pt": "polvo gigante",
-    "name_ca": "pop gegant"
+    "name_ca": "pop gegant",
+    "name_de": "Riesenkrake"
   },
   {
     "node": 34570,
@@ -2615,7 +2852,8 @@
     "name_fr": "calmar à grandes nageoires",
     "name_it": "calamaro di lesson",
     "name_pt": "lula de glitter",
-    "name_ca": "calamar d'aleta gran"
+    "name_ca": "calamar d'aleta gran",
+    "name_de": "Sepia"
   },
   {
     "node": 34578,
@@ -2626,7 +2864,8 @@
     "name_fr": "nautile",
     "name_it": "nautilo",
     "name_pt": "náutilo",
-    "name_ca": "nàutil"
+    "name_ca": "nàutil",
+    "name_de": "Perlboot"
   },
   {
     "node": 51359,
@@ -2637,7 +2876,8 @@
     "name_fr": "pic",
     "name_it": "picchio",
     "name_pt": "pica-pau",
-    "name_ca": "picot negre"
+    "name_ca": "picot negre",
+    "name_de": "Helmspecht"
   },
   {
     "node": 2082998,
@@ -2648,7 +2888,8 @@
     "name_fr": "colibri",
     "name_it": "colibrì",
     "name_pt": "beija-flor",
-    "name_ca": "colibrí"
+    "name_ca": "colibrí",
+    "name_de": "Kolibri"
   },
   {
     "node": 52810,
@@ -2659,7 +2900,8 @@
     "name_fr": "milan",
     "name_it": "nibbio bruno",
     "name_pt": "milhafre",
-    "name_ca": "milà negre"
+    "name_ca": "milà negre",
+    "name_de": "Schwarzmilan"
   },
   {
     "node": 43455,
@@ -2670,7 +2912,8 @@
     "name_fr": "urubu à tête rouge",
     "name_it": "avvoltoio collorosso",
     "name_pt": "urubu-de-cabeça-vermelha",
-    "name_ca": "zopilot capvermell"
+    "name_ca": "zopilot capvermell",
+    "name_de": "Truthahngeier"
   },
   {
     "node": 96725,
@@ -2681,7 +2924,8 @@
     "name_fr": "scinque",
     "name_it": "scinco",
     "name_pt": "lagarto",
-    "name_ca": "esquinc de llengua blava"
+    "name_ca": "esquinc de llengua blava",
+    "name_de": "Blauzungenskink"
   },
   {
     "node": 212017,
@@ -2692,7 +2936,8 @@
     "name_fr": "punaise d'eau",
     "name_it": "cimice d'acqua",
     "name_pt": "barata d'água",
-    "name_ca": "escarabat d'aigua"
+    "name_ca": "escarabat d'aigua",
+    "name_de": "Wasserwanze"
   },
   {
     "node": 209230,
@@ -2703,7 +2948,8 @@
     "name_fr": "poisson combattant",
     "name_it": "pesce betta",
     "name_pt": "peixe betta",
-    "name_ca": "gourami"
+    "name_ca": "gourami",
+    "name_de": "Roter Kampffisch"
   },
   {
     "node": 129333,
@@ -2714,7 +2960,8 @@
     "name_fr": "python vert",
     "name_it": "pitone verde",
     "name_pt": "píton verde",
-    "name_ca": "pitó verd"
+    "name_ca": "pitó verd",
+    "name_de": "Grüner Baumpython"
   },
   {
     "node": 1647984,
@@ -2725,7 +2972,8 @@
     "name_fr": "crabe violoniste",
     "name_it": "granchio violino",
     "name_pt": "caranguejo violinista",
-    "name_ca": "cranc violinista"
+    "name_ca": "cranc violinista",
+    "name_de": "Winkerkrabbe"
   },
   {
     "node": 9927,
@@ -2736,7 +2984,8 @@
     "name_fr": "gnou",
     "name_it": "gnù",
     "name_pt": "gnu",
-    "name_ca": "nyu"
+    "name_ca": "nyu",
+    "name_de": "Gnu"
   },
   {
     "node": 50434,
@@ -2747,7 +2996,8 @@
     "name_fr": "puce",
     "name_it": "pulce",
     "name_pt": "pulga",
-    "name_ca": "puça"
+    "name_ca": "puça",
+    "name_de": "Hundefloh"
   },
   {
     "node": 7897,
@@ -2758,7 +3008,8 @@
     "name_fr": "coelacanthe",
     "name_it": "celacanto",
     "name_pt": "celacanto",
-    "name_ca": "celacant"
+    "name_ca": "celacant",
+    "name_de": "Quastenflosser"
   },
   {
     "node": 202113,
@@ -2769,7 +3020,8 @@
     "name_fr": "éponge",
     "name_it": "spugna di mare",
     "name_pt": "esponja do mar",
-    "name_ca": "esponja de mar"
+    "name_ca": "esponja de mar",
+    "name_de": "Meeresschwamm"
   },
   {
     "node": 8839,
@@ -2780,7 +3032,8 @@
     "name_fr": "canard",
     "name_it": "papera",
     "name_pt": "pato",
-    "name_ca": "ànec"
+    "name_ca": "ànec",
+    "name_de": "Stockente"
   },
   {
     "node": 9103,
@@ -2791,7 +3044,8 @@
     "name_fr": "dindon",
     "name_it": "tacchino",
     "name_pt": "peru",
-    "name_ca": "gall dindi"
+    "name_ca": "gall dindi",
+    "name_de": "Truthahn"
   },
   {
     "node": 9606,
@@ -2802,7 +3056,8 @@
     "name_fr": "humain",
     "name_it": "umano",
     "name_pt": "humano",
-    "name_ca": "humà"
+    "name_ca": "humà",
+    "name_de": "Mensch"
   },
   {
     "node": 9612,
@@ -2813,7 +3068,8 @@
     "name_fr": "loup",
     "name_it": "lupo",
     "name_pt": "lobo",
-    "name_ca": "llop"
+    "name_ca": "llop",
+    "name_de": "Wolf"
   },
   {
     "node": 9685,
@@ -2824,7 +3080,8 @@
     "name_fr": "chat",
     "name_it": "gatto",
     "name_pt": "gato",
-    "name_ca": "gat"
+    "name_ca": "gat",
+    "name_de": "Katze"
   },
   {
     "node": 9733,
@@ -2835,7 +3092,8 @@
     "name_fr": "orque",
     "name_it": "orca",
     "name_pt": "orca",
-    "name_ca": "orca"
+    "name_ca": "orca",
+    "name_de": "Orca"
   },
   {
     "node": 9793,
@@ -2846,7 +3104,8 @@
     "name_fr": "âne",
     "name_it": "asino",
     "name_pt": "burro",
-    "name_ca": "ase"
+    "name_ca": "ase",
+    "name_de": "Esel"
   },
   {
     "node": 9823,
@@ -2857,7 +3116,8 @@
     "name_fr": "cochon",
     "name_it": "maiale",
     "name_pt": "javali",
-    "name_ca": "porc senglar"
+    "name_ca": "porc senglar",
+    "name_de": "Schwein"
   },
   {
     "node": 9874,
@@ -2868,7 +3128,8 @@
     "name_fr": "cerf de virginie",
     "name_it": "cervo",
     "name_pt": "cervo",
-    "name_ca": "cérvol"
+    "name_ca": "cérvol",
+    "name_de": "Weißwedelhirsch"
   },
   {
     "node": 9925,
@@ -2879,7 +3140,8 @@
     "name_fr": "chèvre",
     "name_it": "capra",
     "name_pt": "cabra",
-    "name_ca": "cabra"
+    "name_ca": "cabra",
+    "name_de": "Ziege"
   },
   {
     "node": 9986,
@@ -2890,7 +3152,8 @@
     "name_fr": "lapin",
     "name_it": "coniglio",
     "name_pt": "coelho",
-    "name_ca": "conill"
+    "name_ca": "conill",
+    "name_de": "Kaninchen"
   },
   {
     "node": 27706,
@@ -2901,7 +3164,8 @@
     "name_fr": "perche noire",
     "name_it": "pesce persico",
     "name_pt": "achigã",
-    "name_ca": "perca americana"
+    "name_ca": "perca americana",
+    "name_de": "Barsch"
   },
   {
     "node": 48420,
@@ -2912,7 +3176,8 @@
     "name_fr": "glouton",
     "name_it": "ghiottone",
     "name_pt": "glutão",
-    "name_ca": "golut"
+    "name_ca": "golut",
+    "name_de": "Vielfraß"
   },
   {
     "node": 51900,
@@ -2923,7 +3188,8 @@
     "name_fr": "ara",
     "name_it": "ara",
     "name_pt": "arara-azul",
-    "name_ca": "guacamai jacint"
+    "name_ca": "guacamai jacint",
+    "name_de": "Hyazinthara"
   },
   {
     "node": 163847,
@@ -2934,7 +3200,8 @@
     "name_fr": "serin",
     "name_it": "canarino",
     "name_pt": "canário",
-    "name_ca": "canari"
+    "name_ca": "canari",
+    "name_de": "Kanarienvogel"
   },
   {
     "node": 10116,
@@ -2945,7 +3212,8 @@
     "name_fr": "rat",
     "name_it": "ratto",
     "name_pt": "rato",
-    "name_ca": "rata"
+    "name_ca": "rata",
+    "name_de": "Hausratte"
   },
   {
     "node": 46460,
@@ -2956,6 +3224,7 @@
     "name_fr": "tardigrade",
     "name_it": "tardigrado",
     "name_pt": "tardígrado",
-    "name_ca": "tardígrad"
+    "name_ca": "tardígrad",
+    "name_de": "Wasserbär"
   }
 ]

--- a/Species Lists/plants.json
+++ b/Species Lists/plants.json
@@ -4,1371 +4,1567 @@
     "scientific name": "Prunus dulcis",
     "name": "almond",
     "parent": 3754,
-    "name_es": "almendra"
+    "name_es": "almendra",
+    "name_de": "Mandel"
   },
   {
     "node": 3752,
     "scientific name": "Malus sylvestris",
     "name": "apple",
     "parent": 3749,
-    "name_es": "manzana"
+    "name_es": "manzana",
+    "name_de": "Apfel"
   },
   {
     "node": 36596,
     "scientific name": "Prunus armeniaca",
     "name": "apricot",
     "parent": 3754,
-    "name_es": "albaricoque"
+    "name_es": "albaricoque",
+    "name_de": "Aprikose"
   },
   {
     "node": 4686,
     "scientific name": "Asparagus officinalis",
     "name": "asparagus",
     "parent": 4685,
-    "name_es": "esp\u00e1rragos"
+    "name_es": "espárragos",
+    "name_de": "Spargel"
   },
   {
     "node": 3435,
     "scientific name": "Persea americana",
     "name": "avocado",
     "parent": 3434,
-    "name_es": "palta"
+    "name_es": "palta",
+    "name_de": "Avocado"
   },
   {
     "node": 13216,
     "scientific name": "Piper nigrum",
     "name": "black pepper",
     "parent": 13215,
-    "name_es": "pimienta negra"
+    "name_es": "pimienta negra",
+    "name_de": "Schwarzer Pfeffer"
   },
   {
     "node": 3645,
     "scientific name": "Bertholletia excelsa",
     "name": "brazil nut",
     "parent": 3644,
-    "name_es": "nuez de Brasil"
+    "name_es": "nuez de Brasil",
+    "name_de": "Paranuss"
   },
   {
     "node": 194251,
     "scientific name": "Artocarpus altilis",
     "name": "breadfruit",
     "parent": 3488,
-    "name_es": "panapen"
+    "name_es": "panapen",
+    "name_de": "Brotfrucht"
   },
   {
     "node": 3617,
     "scientific name": "Fagopyrum esculentum",
     "name": "buckwheat",
     "parent": 3616,
-    "name_es": "alforf\u00f3n"
+    "name_es": "alforfón",
+    "name_de": "Buchweizen"
   },
   {
     "node": 3641,
     "scientific name": "Theobroma cacao",
     "name": "cacao",
     "parent": 3640,
-    "name_es": "cacao"
+    "name_es": "cacao",
+    "name_de": "Kakao"
   },
   {
     "node": 3656,
     "scientific name": "Cucumis melo",
     "name": "melon",
     "parent": 3655,
-    "name_es": "mel\u00f3n"
+    "name_es": "melón",
+    "name_de": "Melone"
   },
   {
     "node": 105181,
     "scientific name": "Elettaria cardamomum",
     "name": "cardamom",
     "parent": 105180,
-    "name_es": "cardamomo"
+    "name_es": "cardamomo",
+    "name_de": "Kardamom"
   },
   {
     "node": 171929,
     "scientific name": "Anacardium occidentale",
     "name": "cashew",
     "parent": 171928,
-    "name_es": "anacardo"
+    "name_es": "anacardo",
+    "name_de": "Cashew"
   },
   {
     "node": 3983,
     "scientific name": "Manihot esculenta",
     "name": "cassava",
     "parent": 3982,
-    "name_es": "mandioca"
+    "name_es": "mandioca",
+    "name_de": "Maniok"
   },
   {
     "node": 4045,
     "scientific name": "Apium graveolens",
     "name": "celery",
     "parent": 4044,
-    "name_es": "apio"
+    "name_es": "apio",
+    "name_de": "Sellerie"
   },
   {
     "node": 21020,
     "scientific name": "Castanea sativa",
     "name": "chestnut",
     "parent": 21019,
-    "name_es": "casta\u00f1a"
+    "name_es": "castaña",
+    "name_de": "Kastanie"
   },
   {
     "node": 13427,
     "scientific name": "Cichorium intybus",
     "name": "chicory",
     "parent": 13426,
-    "name_es": "achicoria"
+    "name_es": "achicoria",
+    "name_de": "Chicorée"
   },
   {
     "node": 128608,
     "scientific name": "Cinnamomum verum",
     "name": "cinnamon",
     "parent": 13428,
-    "name_es": "canela"
+    "name_es": "canela",
+    "name_de": "Zimt"
   },
   {
     "node": 13894,
     "scientific name": "Cocos nucifera",
     "name": "coconut",
     "parent": 13893,
-    "name_es": "coco"
+    "name_es": "coco",
+    "name_de": "Kokosnuss"
   },
   {
     "node": 4577,
     "scientific name": "Zea mays",
     "name": "corn",
     "parent": 4575,
-    "name_es": "ma\u00edz"
+    "name_es": "maíz",
+    "name_de": "Mais"
   },
   {
     "node": 3659,
     "scientific name": "Cucumis sativus",
     "name": "cucumber",
     "parent": 3655,
-    "name_es": "pepino"
+    "name_es": "pepino",
+    "name_de": "Gurke"
   },
   {
     "node": 42345,
     "scientific name": "Phoenix dactylifera",
     "name": "date",
     "parent": 4719,
-    "name_es": "fecha"
+    "name_es": "fecha",
+    "name_de": "Dattel"
   },
   {
     "node": 13451,
     "scientific name": "Corylus avellana",
     "name": "hazelnut",
     "parent": 13450,
-    "name_es": "avellana"
+    "name_es": "avellana",
+    "name_de": "Haselnuss"
   },
   {
     "node": 4006,
     "scientific name": "Linum usitatissimum",
     "name": "flax",
     "parent": 4005,
-    "name_es": "linaza"
+    "name_es": "linaza",
+    "name_de": "Lein"
   },
   {
     "node": 4682,
     "scientific name": "Allium sativum",
     "name": "garlic",
     "parent": 4678,
-    "name_es": "ajo"
+    "name_es": "ajo",
+    "name_de": "Knoblauch"
   },
   {
     "node": 94328,
     "scientific name": "Zingiber officinale",
     "name": "ginger",
     "parent": 4650,
-    "name_es": "jengibre"
+    "name_es": "jengibre",
+    "name_de": "Ingwer"
   },
   {
     "node": 29760,
     "scientific name": "Vitis vinifera",
     "name": "grape",
     "parent": 3603,
-    "name_es": "uva"
+    "name_es": "uva",
+    "name_de": "Weintraube"
   },
   {
     "node": 4509,
     "scientific name": "Dactylis glomerata",
     "name": "orchard grass",
     "parent": 4508,
-    "name_es": "hierba de huerto"
+    "name_es": "hierba de huerto",
+    "name_de": "Knaulgras"
   },
   {
     "node": 120290,
     "scientific name": "Psidium guajava",
     "name": "guava",
     "parent": 120289,
-    "name_es": "guayaba"
+    "name_es": "guayaba",
+    "name_de": "Guave"
   },
   {
     "node": 3483,
     "scientific name": "Cannabis sativa",
     "name": "hemp",
     "parent": 3482,
-    "name_es": "c\u00e1\u00f1amo"
+    "name_es": "cáñamo",
+    "name_de": "Hanf"
   },
   {
     "node": 141191,
     "scientific name": "Lawsonia inermis",
     "name": "henna",
     "parent": 141190,
-    "name_es": "alhe\u00f1a"
+    "name_es": "alheña",
+    "name_de": "Henna"
   },
   {
     "node": 3486,
     "scientific name": "Humulus lupulus",
     "name": "hop",
     "parent": 3484,
-    "name_es": "brincar"
+    "name_es": "brincar",
+    "name_de": "Hopfen"
   },
   {
     "node": 3704,
     "scientific name": "Armoracia rusticana",
     "name": "horseradish",
     "parent": 3703,
-    "name_es": "r\u00e1bano picante"
+    "name_es": "rábano picante",
+    "name_de": "Meerrettich"
   },
   {
     "node": 66014,
     "scientific name": "Cymbopogon citratus",
     "name": "lemongrass",
     "parent": 66013,
-    "name_es": "la hierba de lim\u00f3n"
+    "name_es": "la hierba de limón",
+    "name_de": "Zitronengras"
   },
   {
     "node": 4236,
     "scientific name": "Lactuca sativa",
     "name": "lettuce",
     "parent": 4235,
-    "name_es": "lechuga"
+    "name_es": "lechuga",
+    "name_de": "Kopfsalat"
   },
   {
     "node": 151069,
     "scientific name": "Litchi chinensis",
     "name": "lychee",
     "parent": 151068,
-    "name_es": "lychee"
+    "name_es": "lychee",
+    "name_de": "Litschi"
   },
   {
     "node": 60698,
     "scientific name": "Macadamia integrifolia",
     "name": "macadamia nut",
     "parent": 4329,
-    "name_es": "nuez de macadamia"
+    "name_es": "nuez de macadamia",
+    "name_de": "Macadamianuss"
   },
   {
     "node": 51089,
     "scientific name": "Myristica fragrans",
     "name": "mace",
     "parent": 51088,
-    "name_es": "mazo"
+    "name_es": "mazo",
+    "name_de": "Muskatblüte"
   },
   {
     "node": 39510,
     "scientific name": "Agave americana",
     "name": "agave",
     "parent": 39509,
-    "name_es": "agave"
+    "name_es": "agave",
+    "name_de": "Agave"
   },
   {
     "node": 85571,
     "scientific name": "Citrus reticulata",
     "name": "mandarin",
     "parent": 2706,
-    "name_es": "mandar\u00edn"
+    "name_es": "mandarín",
+    "name_de": "Mandarine"
   },
   {
     "node": 29780,
     "scientific name": "Mangifera indica",
     "name": "mango",
     "parent": 23461,
-    "name_es": "mango"
+    "name_es": "mango",
+    "name_de": "Mango"
   },
   {
     "node": 3498,
     "scientific name": "Morus alba",
     "name": "silkworm mulberry",
     "parent": 3497,
-    "name_es": "morera de gusano de seda"
+    "name_es": "morera de gusano de seda",
+    "name_de": "Weiße Maulbeere"
   },
   {
     "node": 3710,
     "scientific name": "Brassica nigra",
     "name": "black mustard",
     "parent": 3705,
-    "name_es": "mostaza negra"
+    "name_es": "mostaza negra",
+    "name_de": "Schwarzer Senf"
   },
   {
     "node": 51089,
     "scientific name": "Myristica fragrans",
     "name": "nutmeg",
     "parent": 51088,
-    "name_es": "tuerca"
+    "name_es": "tuerca",
+    "name_de": "Muskatblüte"
   },
   {
     "node": 51953,
     "scientific name": "Elaeis guineensis",
     "name": "oil palm",
     "parent": 51952,
-    "name_es": "aceite de palma"
+    "name_es": "aceite de palma",
+    "name_de": "Ölpalme"
   },
   {
     "node": 455045,
     "scientific name": "Abelmoschus esculentus",
     "name": "okra",
     "parent": 183218,
-    "name_es": "okra"
+    "name_es": "okra",
+    "name_de": "Okra"
   },
   {
     "node": 4146,
     "scientific name": "Olea europaea",
     "name": "olive",
     "parent": 4145,
-    "name_es": "aceituna"
+    "name_es": "aceituna",
+    "name_de": "Olive"
   },
   {
     "node": 3649,
     "scientific name": "Carica papaya",
     "name": "papaya",
     "parent": 3648,
-    "name_es": "papaya"
+    "name_es": "papaya",
+    "name_de": "Papaya"
   },
   {
     "node": 4041,
     "scientific name": "Pastinaca sativa",
     "name": "parsnip",
     "parent": 4040,
-    "name_es": "chiriv\u00eda"
+    "name_es": "chirivía",
+    "name_de": "Pastinake"
   },
   {
     "node": 3760,
     "scientific name": "Prunus persica",
     "name": "peach",
     "parent": 3754,
-    "name_es": "durazno"
+    "name_es": "durazno",
+    "name_de": "Pfirsich"
   },
   {
     "node": 23211,
     "scientific name": "Pyrus communis",
     "name": "pear",
     "parent": 3766,
-    "name_es": "pera"
+    "name_es": "pera",
+    "name_de": "Birne"
   },
   {
     "node": 13493,
     "scientific name": "Diospyros virginiana",
     "name": "persimmon",
     "parent": 13492,
-    "name_es": "caqui"
+    "name_es": "caqui",
+    "name_de": "Persimone"
   },
   {
     "node": 55513,
     "scientific name": "Pistacia vera",
     "name": "pistachio",
     "parent": 55512,
-    "name_es": "pistacho"
+    "name_es": "pistacho",
+    "name_de": "Pistazie"
   },
   {
     "node": 3758,
     "scientific name": "Prunus domestica",
     "name": "plum",
     "parent": 3754,
-    "name_es": "ciruela"
+    "name_es": "ciruela",
+    "name_de": "Pflaume"
   },
   {
     "node": 22663,
     "scientific name": "Punica granatum",
     "name": "pomegranate",
     "parent": 22662,
-    "name_es": "granada"
+    "name_es": "granada",
+    "name_de": "Granatapfel"
   },
   {
     "node": 3469,
     "scientific name": "Papaver somniferum",
     "name": "poppy",
     "parent": 3468,
-    "name_es": "amapola"
+    "name_es": "amapola",
+    "name_de": "Mohn"
   },
   {
     "node": 4120,
     "scientific name": "Ipomoea batatas",
     "name": "sweet potato",
     "parent": 4119,
-    "name_es": "batata"
+    "name_es": "batata",
+    "name_de": "Süßkartoffel"
   },
   {
     "node": 63459,
     "scientific name": "Chenopodium quinoa",
     "name": "quinoa",
     "parent": 3558,
-    "name_es": "quinua"
+    "name_es": "quinua",
+    "name_de": "Quinoa"
   },
   {
     "node": 3726,
     "scientific name": "Raphanus sativus",
     "name": "radish",
     "parent": 3725,
-    "name_es": "r\u00e1bano"
+    "name_es": "rábano",
+    "name_de": "Radieschen"
   },
   {
     "node": 4530,
     "scientific name": "Oryza sativa",
     "name": "rice",
     "parent": 4527,
-    "name_es": "arroz"
+    "name_es": "arroz",
+    "name_de": "Reis"
   },
   {
     "node": 3981,
     "scientific name": "Hevea brasiliensis",
     "name": "rubber",
     "parent": 3980,
-    "name_es": "goma"
+    "name_es": "goma",
+    "name_de": "Kautschuk"
   },
   {
     "node": 4550,
     "scientific name": "Secale cereale",
     "name": "rye",
     "parent": 4549,
-    "name_es": "centeno"
+    "name_es": "centeno",
+    "name_de": "Roggen"
   },
   {
     "node": 292385,
     "scientific name": "Vitellaria paradoxa",
     "name": "shea nut",
     "parent": 292384,
-    "name_es": "nuez"
+    "name_es": "nuez",
+    "name_de": "Sheanuss"
   },
   {
     "node": 4182,
     "scientific name": "Sesamum indicum",
     "name": "sesame",
     "parent": 4181,
-    "name_es": "s\u00e9samo"
+    "name_es": "sésamo",
+    "name_de": "Sesam"
   },
   {
     "node": 58933,
     "scientific name": "Triticum spelta",
     "name": "spelt",
     "parent": 4564,
-    "name_es": "espelta"
+    "name_es": "espelta",
+    "name_de": "Dinkel"
   },
   {
     "node": 3562,
     "scientific name": "Spinacia oleracea",
     "name": "spinach",
     "parent": 3561,
-    "name_es": "espinaca"
+    "name_es": "espinaca",
+    "name_de": "Spinat"
   },
   {
     "node": 4232,
     "scientific name": "Helianthus annuus",
     "name": "sunflower",
     "parent": 4231,
-    "name_es": "girasol"
+    "name_es": "girasol",
+    "name_de": "Sonnenblume"
   },
   {
     "node": 4072,
     "scientific name": "Capsicum annuum",
     "name": "sweet pepper",
     "parent": 4071,
-    "name_es": "pimienta dulce"
+    "name_es": "pimienta dulce",
+    "name_de": "Paprika"
   },
   {
     "node": 4460,
     "scientific name": "Colocasia esculenta",
     "name": "taro",
     "parent": 4459,
-    "name_es": "taro"
+    "name_es": "taro",
+    "name_de": "Taro"
   },
   {
     "node": 4442,
     "scientific name": "Camellia sinensis",
     "name": "tea",
     "parent": 4441,
-    "name_es": "t\u00e9"
+    "name_es": "té",
+    "name_de": "Tee"
   },
   {
     "node": 4097,
     "scientific name": "Nicotiana tabacum",
     "name": "tobacco",
     "parent": 4085,
-    "name_es": "tabaco"
+    "name_es": "tabaco",
+    "name_de": "Tabak"
   },
   {
     "node": 51239,
     "scientific name": "Vanilla planifolia",
     "name": "vanilla",
     "parent": 51238,
-    "name_es": "vainilla"
+    "name_es": "vainilla",
+    "name_de": "Vanille"
   },
   {
     "node": 3654,
     "scientific name": "Citrullus lanatus",
     "name": "watermelon",
     "parent": 3653,
-    "name_es": "sand\u00eda"
+    "name_es": "sandía",
+    "name_de": "Wassermelone"
   },
   {
     "node": 4565,
     "scientific name": "Triticum aestivum",
     "name": "wheat",
     "parent": 4564,
-    "name_es": "trigo"
+    "name_es": "trigo",
+    "name_de": "Weizen"
   },
   {
     "node": 69109,
     "scientific name": "Adansonia digitata",
     "name": "baobab",
     "parent": 69108,
-    "name_es": "baobab"
+    "name_es": "baobab",
+    "name_de": "Baobab"
   },
   {
     "node": 75706,
     "scientific name": "Salix babylonica",
     "name": "weeping willow",
     "parent": 40685,
-    "name_es": "sauce llor\u00f3n"
+    "name_es": "sauce llorón",
+    "name_de": "Trauerweide"
   },
   {
     "node": 3505,
     "scientific name": "Betula pendula",
     "name": "silver birch",
     "parent": 3504,
-    "name_es": "abedul de plata"
+    "name_es": "abedul de plata",
+    "name_de": "Hängebirke"
   },
   {
     "node": 99814,
     "scientific name": "Sequoiadendron giganteum",
     "name": "giant sequoia",
     "parent": 99813,
-    "name_es": "sequoia gigante"
+    "name_es": "sequoia gigante",
+    "name_de": "Riesenmammutbaum"
   },
   {
     "node": 3357,
     "scientific name": "Pseudotsuga menziesii",
     "name": "douglas fir",
     "parent": 3356,
-    "name_es": "abeto de douglas"
+    "name_es": "abeto de douglas",
+    "name_de": "Douglasie"
   },
   {
     "node": 93692,
     "scientific name": "Cedrus libani",
     "name": "cedar of lebanon",
     "parent": 3321,
-    "name_es": "cedro del L\u00edbano"
+    "name_es": "cedro del Líbano",
+    "name_de": "Libanon-Zeder"
   },
   {
     "node": 3349,
     "scientific name": "Pinus sylvestris",
     "name": "baltic pine",
     "parent": 139271,
-    "name_es": "pino b\u00e1ltico"
+    "name_es": "pino báltico",
+    "name_de": "Waldkiefer"
   },
   {
     "node": 3329,
     "scientific name": "Picea abies",
     "name": "spruce",
     "parent": 3328,
-    "name_es": "abeto"
+    "name_es": "abeto",
+    "name_de": "Fichte"
   },
   {
     "node": 4081,
     "scientific name": "Solanum lycopersicum",
     "name": "tomato",
     "parent": 49274,
-    "name_es": "tomate"
+    "name_es": "tomate",
+    "name_de": "Tomate"
   },
   {
     "node": 4111,
     "scientific name": "Solanum melongena",
     "name": "eggplant",
     "parent": 4107,
-    "name_es": "berenjena"
+    "name_es": "berenjena",
+    "name_de": "Aubergine"
   },
   {
     "node": 4113,
     "scientific name": "Solanum tuberosum",
     "name": "potato",
     "parent": 4107,
-    "name_es": "papa"
+    "name_es": "papa",
+    "name_de": "Kartoffel"
   },
   {
     "node": 4679,
     "scientific name": "Allium cepa",
     "name": "onion",
     "parent": 4678,
-    "name_es": "cebolla"
+    "name_es": "cebolla",
+    "name_de": "Zwiebel"
   },
   {
     "node": 4615,
     "scientific name": "Ananas comosus",
     "name": "pineapple",
     "parent": 4614,
-    "name_es": "pi\u00f1a"
+    "name_es": "piña",
+    "name_de": "Ananas"
   },
   {
     "node": 38942,
     "scientific name": "Quercus robur",
     "name": "oak",
     "parent": 3511,
-    "name_es": "roble"
+    "name_es": "roble",
+    "name_de": "Eiche"
   },
   {
     "node": 28930,
     "scientific name": "Fagus sylvatica",
     "name": "common beech",
     "parent": 21024,
-    "name_es": "hayas comunes"
+    "name_es": "hayas comunes",
+    "name_de": "Rotbuche"
   },
   {
     "node": 3885,
     "scientific name": "Phaseolus vulgaris",
     "name": "common bean",
     "parent": 3883,
-    "name_es": "frijol com\u00fan"
+    "name_es": "frijol común",
+    "name_de": "Gartenbohne"
   },
   {
     "node": 3906,
     "scientific name": "Vicia faba",
     "name": "fava bean",
     "parent": 3904,
-    "name_es": "frijol fava"
+    "name_es": "frijol fava",
+    "name_de": "Dicke Bohne"
   },
   {
     "node": 3847,
     "scientific name": "Glycine max",
     "name": "soy bean",
     "parent": 1462606,
-    "name_es": "soy bean"
+    "name_es": "soy bean",
+    "name_de": "Sojabohne"
   },
   {
     "node": 3888,
     "scientific name": "Pisum sativum",
     "name": "garden pea",
     "parent": 3887,
-    "name_es": "guisante de jard\u00edn"
+    "name_es": "guisante de jardín",
+    "name_de": "Erbse"
   },
   {
     "node": 3917,
     "scientific name": "Vigna unguiculata",
     "name": "black eyed pea",
     "parent": 3913,
-    "name_es": "guisante de ojos negros"
+    "name_es": "guisante de ojos negros",
+    "name_de": "Augenbohne"
   },
   {
     "node": 3827,
     "scientific name": "Cicer arietinum",
     "name": "chickpea",
     "parent": 3826,
-    "name_es": "garbanzo"
+    "name_es": "garbanzo",
+    "name_de": "Kichererbse"
   },
   {
     "node": 3864,
     "scientific name": "Lens culinaris",
     "name": "lentil",
     "parent": 3863,
-    "name_es": "lenteja"
+    "name_es": "lenteja",
+    "name_de": "Linse"
   },
   {
     "node": 3818,
     "scientific name": "Arachis hypogaea",
     "name": "peanut",
     "parent": 3817,
-    "name_es": "man\u00ed"
+    "name_es": "maní",
+    "name_de": "Erdnuss"
   },
   {
     "node": 20340,
     "scientific name": "Ceratonia siliqua",
     "name": "carob",
     "parent": 20339,
-    "name_es": "algarroba"
+    "name_es": "algarroba",
+    "name_de": "Johannisbrot"
   },
   {
     "node": 49827,
     "scientific name": "Glycyrrhiza glabra",
     "name": "licorice",
     "parent": 46347,
-    "name_es": "regaliz"
+    "name_es": "regaliz",
+    "name_de": "Süßholz"
   },
   {
     "node": 138033,
     "scientific name": "Vachellia nilotica",
     "name": "gum arabic tree",
     "parent": 468162,
-    "name_es": "goma de goma de \u00e1rbol \u00e1rabe"
+    "name_es": "goma de goma de árbol árabe",
+    "name_de": "Gummiarabikumbaum"
   },
   {
     "node": 58860,
     "scientific name": "Tamarindus indica",
     "name": "tamarind",
     "parent": 58859,
-    "name_es": "tamarindo"
+    "name_es": "tamarindo",
+    "name_de": "Tamarinde"
   },
   {
     "node": 3879,
     "scientific name": "Medicago sativa",
     "name": "alfalfa",
     "parent": 3877,
-    "name_es": "alfalfa"
+    "name_es": "alfalfa",
+    "name_de": "Luzerne"
   },
   {
     "node": 3859,
     "scientific name": "Lathyrus odoratus",
     "name": "sweet pea",
     "parent": 3853,
-    "name_es": "guisante dulce"
+    "name_es": "guisante dulce",
+    "name_de": "Duftwicke"
   },
   {
     "node": 76306,
     "scientific name": "Mimosa pudica",
     "name": "touch-me-not",
     "parent": 21013,
-    "name_es": "nometoques"
+    "name_es": "nometoques",
+    "name_de": "Schamhafte Mimose"
   },
   {
     "node": 72402,
     "scientific name": "Senna alexandrina",
     "name": "senna",
     "parent": 53922,
-    "name_es": "senna"
+    "name_es": "senna",
+    "name_de": "Sennes"
   },
   {
     "node": 3902,
     "scientific name": "Ulex europaeus",
     "name": "gorse",
     "parent": 3901,
-    "name_es": "tojo"
+    "name_es": "tojo",
+    "name_de": "Stechginster"
   },
   {
     "node": 171251,
     "scientific name": "Citrus medica",
     "name": "citron",
     "parent": 2706,
-    "name_es": "cidra"
+    "name_es": "cidra",
+    "name_de": "Zedrat"
   },
   {
     "node": 396733,
     "scientific name": "Rosa x centifolia",
     "name": "rose",
     "parent": 3764,
-    "name_es": "rosa"
+    "name_es": "rosa",
+    "name_de": "Rose"
   },
   {
     "node": 159033,
     "scientific name": "Citrus aurantiifolia",
     "name": "lime",
     "parent": 2706,
-    "name_es": "cal"
+    "name_es": "cal",
+    "name_de": "Limette"
   },
   {
     "node": 2708,
     "scientific name": "Citrus limon",
     "name": "lemon",
     "parent": 2706,
-    "name_es": "lim\u00f3n"
+    "name_es": "limón",
+    "name_de": "Zitrone"
   },
   {
     "node": 75806,
     "scientific name": "Eutrema japonicum",
     "name": "wasabi",
     "parent": 98005,
-    "name_es": "wasabi"
+    "name_es": "wasabi",
+    "name_de": "Wasabi"
   },
   {
     "node": 78817,
     "scientific name": "Ophrys apifera",
     "name": "orchid",
     "parent": 59329,
-    "name_es": "orqu\u00eddea"
+    "name_es": "orquídea",
+    "name_de": "Bienen-Ragwurz"
   },
   {
     "node": 4039,
     "scientific name": "Daucus carota",
     "name": "carrot",
     "parent": 1873447,
-    "name_es": "zanahoria"
+    "name_es": "zanahoria",
+    "name_de": "Karotte"
   },
   {
     "node": 161934,
     "scientific name": "Beta vulgaris",
     "name": "beetroot",
     "parent": 3554,
-    "name_es": "ra\u00edz de remolacha"
+    "name_es": "raíz de remolacha",
+    "name_de": "Rote Bete"
   },
   {
     "node": 42229,
     "scientific name": "Prunus avium",
     "name": "cherry",
     "parent": 3754,
-    "name_es": "cereza"
+    "name_es": "cereza",
+    "name_de": "Kirsche"
   },
   {
     "node": 99038,
     "scientific name": "Glebionis coronaria",
     "name": "daisy",
     "parent": 1478145,
-    "name_es": "margarita"
+    "name_es": "margarita",
+    "name_de": "Garten-Margerite"
   },
   {
     "node": 94688,
     "scientific name": "Leucobryum glaucum",
     "name": "moss",
     "parent": 80888,
-    "name_es": "musgo"
+    "name_es": "musgo",
+    "name_de": "Moos"
   },
   {
     "node": 4681,
     "scientific name": "Allium ampeloprasum",
     "name": "leek",
     "parent": 4678,
-    "name_es": "puerro"
+    "name_es": "puerro",
+    "name_de": "Porree"
   },
   {
     "node": 3663,
     "scientific name": "Cucurbita pepo",
     "name": "pumpkin",
     "parent": 3660,
-    "name_es": "calabaza"
+    "name_es": "calabaza",
+    "name_de": "Kürbis"
   },
   {
     "node": 3662,
     "scientific name": "Cucurbita moschata",
     "name": "butternut squash",
     "parent": 3660,
-    "name_es": "calabaza"
+    "name_es": "calabaza",
+    "name_de": "Butternusskürbis"
   },
   {
     "node": 13306,
     "scientific name": "Tulipa gesneriana",
     "name": "tulip",
     "parent": 13305,
-    "name_es": "tulip\u00e1n"
+    "name_es": "tulipán",
+    "name_de": "Tulpe"
   },
   {
     "node": 4024,
     "scientific name": "Acer saccharum",
     "name": "sugar maple",
     "parent": 4022,
-    "name_es": "arce de az\u00facar"
+    "name_es": "arce de azúcar",
+    "name_de": "Zuckerahorn"
   },
   {
     "node": 190548,
     "scientific name": "Vaccinium uliginosum",
     "name": "blueberry",
     "parent": 13749,
-    "name_es": "ar\u00e1ndano"
+    "name_es": "arándano",
+    "name_de": "Heidelbeere"
   },
   {
     "node": 3747,
     "scientific name": "Fragaria x ananassa",
     "name": "strawberry",
     "parent": 3746,
-    "name_es": "fresa"
+    "name_es": "fresa",
+    "name_de": "Erdbeere"
   },
   {
     "node": 75062,
     "scientific name": "Rubus allegheniensis",
     "name": "blackberry",
     "parent": 23216,
-    "name_es": "mora"
+    "name_es": "mora",
+    "name_de": "Brombeere"
   },
   {
     "node": 32247,
     "scientific name": "Rubus idaeus",
     "name": "raspberry",
     "parent": 23216,
-    "name_es": "frambuesa"
+    "name_es": "frambuesa",
+    "name_de": "Himbeere"
   },
   {
     "node": 13750,
     "scientific name": "Vaccinium macrocarpon",
     "name": "cranberry",
     "parent": 13749,
-    "name_es": "ar\u00e1ndano"
+    "name_es": "arándano",
+    "name_de": "Moosbeere"
   },
   {
     "node": 3712,
     "scientific name": "Brassica oleracea",
     "name": "cabbage",
     "parent": 3705,
-    "name_es": "repollo"
+    "name_es": "repollo",
+    "name_de": "Kohl"
   },
   {
     "node": 3711,
     "scientific name": "Brassica rapa",
     "name": "bok choy",
     "parent": 3705,
-    "name_es": "libro choy"
+    "name_es": "libro choy",
+    "name_de": "Pak Choi"
   },
   {
     "node": 50225,
     "scientific name": "Taraxacum officinale",
     "name": "dandelion",
     "parent": 49743,
-    "name_es": "diente de le\u00f3n"
+    "name_es": "diente de león",
+    "name_de": "Löwenzahn"
   },
   {
     "node": 29719,
     "scientific name": "Mentha spicata",
     "name": "spearmint",
     "parent": 21819,
-    "name_es": "menta verde"
+    "name_es": "menta verde",
+    "name_de": "Grüne Minze"
   },
   {
     "node": 39350,
     "scientific name": "Ocimum basilicum",
     "name": "basil",
     "parent": 39173,
-    "name_es": "albahaca"
+    "name_es": "albahaca",
+    "name_de": "Basilikum"
   },
   {
     "node": 13443,
     "scientific name": "Coffea arabica",
     "name": "coffee",
     "parent": 13442,
-    "name_es": "caf\u00e9"
+    "name_es": "café",
+    "name_de": "Kaffee"
   },
   {
     "node": 39329,
     "scientific name": "Lavandula angustifolia",
     "name": "lavender",
     "parent": 39169,
-    "name_es": "lavanda"
+    "name_es": "lavanda",
+    "name_de": "Lavendel"
   },
   {
     "node": 4043,
     "scientific name": "Petroselinum crispum",
     "name": "parsley",
     "parent": 4042,
-    "name_es": "perejil"
+    "name_es": "perejil",
+    "name_de": "Petersilie"
   },
   {
     "node": 49992,
     "scientific name": "Thymus vulgaris",
     "name": "thyme",
     "parent": 49990,
-    "name_es": "tomillo"
+    "name_es": "tomillo",
+    "name_de": "Thymian"
   },
   {
     "node": 2711,
     "scientific name": "Citrus sinensis",
     "name": "orange",
     "parent": 2706,
-    "name_es": "naranja"
+    "name_es": "naranja",
+    "name_de": "Orange"
   },
   {
     "node": 37656,
     "scientific name": "Citrus x paradisi",
     "name": "grapefruit",
     "parent": 2706,
-    "name_es": "pomelo"
+    "name_es": "pomelo",
+    "name_de": "Grapefruit"
   },
   {
     "node": 130122,
     "scientific name": "Ferocactus flavovirens",
     "name": "cactus",
     "parent": 130120,
-    "name_es": "cactus"
+    "name_es": "cactus",
+    "name_de": "Kaktus"
   },
   {
     "node": 355937,
     "scientific name": "Salsola tragus",
     "name": "tumbleweed",
     "parent": 151233,
-    "name_es": "envolt\u00eda"
+    "name_es": "envoltía",
+    "name_de": "Steppenroller"
   },
   {
     "node": 43853,
     "scientific name": "Toxicodendron radicans",
     "name": "poison ivy",
     "parent": 43852,
-    "name_es": "hiedra venenosa"
+    "name_es": "hiedra venenosa",
+    "name_de": "Giftsumach"
   },
   {
     "node": 4498,
     "scientific name": "Avena sativa",
     "name": "oat",
     "parent": 4496,
-    "name_es": "avena"
+    "name_es": "avena",
+    "name_de": "Hafer"
   },
   {
     "node": 4513,
     "scientific name": "Hordeum vulgare",
     "name": "barley",
     "parent": 4512,
-    "name_es": "cebada"
+    "name_es": "cebada",
+    "name_de": "Gerste"
   },
   {
     "node": 4026,
     "scientific name": "Acer pseudoplatanus",
     "name": "sycamore",
     "parent": 4022,
-    "name_es": "sicomoro"
+    "name_es": "sicomoro",
+    "name_de": "Bergahorn"
   },
   {
     "node": 79002,
     "scientific name": "Lilium lancifolium",
     "name": "tiger lily",
     "parent": 4688,
-    "name_es": "lirio de tigre"
+    "name_es": "lirio de tigre",
+    "name_de": "Tigerlilie"
   },
   {
     "node": 3635,
     "scientific name": "Gossypium hirsutum",
     "name": "cotton",
     "parent": 3633,
-    "name_es": "algod\u00f3n"
+    "name_es": "algodón",
+    "name_de": "Baumwolle"
   },
   {
     "node": 3627,
     "scientific name": "Actinidia deliciosa",
     "name": "kiwi",
     "parent": 3624,
-    "name_es": "kiwi"
+    "name_es": "kiwi",
+    "name_de": "Kiwi"
   },
   {
     "node": 76314,
     "scientific name": "Caulerpa prolifera",
     "name": "seaweed",
     "parent": 76312,
-    "name_es": "algas marinas"
+    "name_es": "algas marinas",
+    "name_de": "Meeresalge"
   },
   {
     "node": 318051,
     "scientific name": "Bambusa textilis",
     "name": "bamboo",
     "parent": 4581,
-    "name_es": "bamb\u00fa"
+    "name_es": "bambú",
+    "name_de": "Bambus"
   },
   {
     "node": 4265,
     "scientific name": "Cynara cardunculus",
     "name": "artichoke",
     "parent": 4264,
-    "name_es": "alcachofa"
+    "name_es": "alcachofa",
+    "name_de": "Artischocke"
   },
   {
     "node": 32201,
     "scientific name": "Carya illinoinensis",
     "name": "pecan",
     "parent": 13402,
-    "name_es": "pacana"
+    "name_es": "pacana",
+    "name_de": "Pekannuss"
   },
   {
     "node": 89151,
     "scientific name": "Musa x paradisiaca",
     "name": "plantain",
     "parent": 4640,
-    "name_es": "pl\u00e1tano"
+    "name_es": "plátano",
+    "name_de": "Kochbanane"
   },
   {
     "node": 4547,
     "scientific name": "Saccharum officinarum",
     "name": "sugarcane",
     "parent": 286192,
-    "name_es": "ca\u00f1a de az\u00facar"
+    "name_es": "caña de azúcar",
+    "name_de": "Zuckerrohr"
   },
   {
     "node": 29710,
     "scientific name": "Dioscorea cayenensis",
     "name": "yam",
     "parent": 4672,
-    "name_es": "batata"
+    "name_es": "batata",
+    "name_de": "Yams"
   },
   {
     "node": 3621,
     "scientific name": "Rheum rhabarbarum",
     "name": "rhubarb",
     "parent": 3620,
-    "name_es": "ruibarbo"
+    "name_es": "ruibarbo",
+    "name_de": "Rhabarber"
   },
   {
     "node": 146995,
     "scientific name": "Chrysanthemum indicum",
     "name": "chrysanthemum",
     "parent": 13422,
-    "name_es": "crisantemo"
+    "name_es": "crisantemo",
+    "name_de": "Chrysantheme"
   },
   {
     "node": 361556,
     "scientific name": "Sphaeropteris medullaris",
     "name": "fern",
     "parent": 32081,
-    "name_es": "helecho"
+    "name_es": "helecho",
+    "name_de": "Farn"
   },
   {
     "node": 126433,
     "scientific name": "Jasminum officinale",
     "name": "jasmine",
     "parent": 4147,
-    "name_es": "jazm\u00edn"
+    "name_es": "jazmín",
+    "name_de": "Jasmin"
   },
   {
     "node": 34301,
     "scientific name": "Nymphaea alba",
     "name": "water lily",
     "parent": 4418,
-    "name_es": "lirio de agua"
+    "name_es": "lirio de agua",
+    "name_de": "Seerose"
   },
   {
     "node": 4432,
     "scientific name": "Nelumbo nucifera",
     "name": "lotus",
     "parent": 4430,
-    "name_es": "loto"
+    "name_es": "loto",
+    "name_de": "Lotus"
   },
   {
     "node": 106335,
     "scientific name": "Hibiscus syriacus",
     "name": "hibiscus",
     "parent": 47605,
-    "name_es": "hibisco"
+    "name_es": "hibisco",
+    "name_de": "Hibiskus"
   },
   {
     "node": 85868,
     "scientific name": "Magnolia sieboldii",
     "name": "magnolia",
     "parent": 3402,
-    "name_es": "magnolia"
+    "name_es": "magnolia",
+    "name_de": "Magnolie"
   },
   {
     "node": 69717,
     "scientific name": "Paeonia officinalis",
     "name": "peony",
     "parent": 13625,
-    "name_es": "peon\u00eda"
+    "name_es": "peonía",
+    "name_de": "Pfingstrose"
   },
   {
     "node": 98504,
     "scientific name": "Matricaria chamomilla",
     "name": "chamomile",
     "parent": 56016,
-    "name_es": "manzanilla"
+    "name_es": "manzanilla",
+    "name_de": "Kamille"
   },
   {
     "node": 54855,
     "scientific name": "Narcissus poeticus",
     "name": "daffodil",
     "parent": 4697,
-    "name_es": "narciso"
+    "name_es": "narciso",
+    "name_de": "Narzisse"
   },
   {
     "node": 97021,
     "scientific name": "Trifolium dubium",
     "name": "clover",
     "parent": 3898,
-    "name_es": "tr\u00e9bol"
+    "name_es": "trébol",
+    "name_de": "Klee"
   },
   {
     "node": 97424,
     "scientific name": "Viola cucullata",
     "name": "violet",
     "parent": 2985427,
-    "name_es": "violeta"
+    "name_es": "violeta",
+    "name_de": "Veilchen"
   },
   {
     "node": 101596,
     "scientific name": "Dahlia pinnata",
     "name": "dahlia",
     "parent": 41562,
-    "name_es": "dalia"
+    "name_es": "dalia",
+    "name_de": "Dahlie"
   },
   {
     "node": 16719,
     "scientific name": "Juglans nigra",
     "name": "walnut",
     "parent": 16718,
-    "name_es": "nuez"
+    "name_es": "nuez",
+    "name_de": "Walnuss"
   },
   {
     "node": 3494,
     "scientific name": "Ficus carica",
     "name": "fig",
     "parent": 3493,
-    "name_es": "higo"
+    "name_es": "higo",
+    "name_de": "Feige"
   },
   {
     "node": 3570,
     "scientific name": "Dianthus caryophyllus",
     "name": "carnation",
     "parent": 3569,
-    "name_es": "clavel"
+    "name_es": "clavel",
+    "name_de": "Nelke"
   },
   {
     "node": 4362,
     "scientific name": "Dionaea muscipula",
     "name": "venus flytrap",
     "parent": 4361,
-    "name_es": "venus atrapamoscas"
+    "name_es": "venus atrapamoscas",
+    "name_de": "Venusfliegenfalle"
   },
   {
     "node": 89151,
     "scientific name": "Musa x paradisiaca",
     "name": "banana",
     "parent": 4640,
-    "name_es": "banana"
+    "name_es": "banana",
+    "name_de": "Kochbanane"
   },
   {
     "node": 1125938,
     "scientific name": "Selenicereus costaricensis",
     "name": "dragon fruit",
     "parent": 83431,
-    "name_es": "pitahaya"
+    "name_es": "pitahaya",
+    "name_de": "Drachenfrucht"
   },
   {
     "node": 2849586,
     "scientific name": "Anethum foeniculum",
     "name": "fennel",
     "parent": 40921,
-    "name_es": "hinojo"
+    "name_es": "hinojo",
+    "name_de": "Fenchel"
   },
   {
     "node": 40922,
     "scientific name": "Anethum graveolens",
     "name": "dill",
     "parent": 40921,
-    "name_es": "eneldo"
+    "name_es": "eneldo",
+    "name_de": "Dill"
   },
   {
     "node": 36592,
     "scientific name": "Eucalyptus obliqua",
     "name": "eucalyptus tree",
     "parent": 3932,
-    "name_es": "\u00e1rbol de eucalipto"
+    "name_es": "árbol de eucalipto",
+    "name_de": "Eukalyptusbaum"
   },
   {
     "node": 65948,
     "scientific name": "Nasturtium officinale",
     "name": "watercress",
     "parent": 65947,
-    "name_es": "berro"
+    "name_es": "berro",
+    "name_de": "Brunnenkresse"
   },
   {
     "node": 82025,
     "scientific name": "Hyacinthus orientalis",
     "name": "hyacinth",
     "parent": 82024,
-    "name_es": "jacinto"
+    "name_es": "jacinto",
+    "name_de": "Hyazinthe"
   },
   {
     "node": 3922,
     "scientific name": "Wisteria floribunda",
     "name": "wisteria",
     "parent": 3921,
-    "name_es": "glicinia"
+    "name_es": "glicinia",
+    "name_de": "Blauregen"
   },
   {
     "node": 35974,
     "scientific name": "Santalum album",
     "name": "sandalwood",
     "parent": 35973,
-    "name_es": "s\u00e1ndalo"
+    "name_es": "sándalo",
+    "name_de": "Sandelholz"
   },
   {
     "node": 12953,
     "scientific name": "Asimina triloba",
     "name": "pawpaw",
     "parent": 12952,
-    "name_es": "papaya"
+    "name_es": "papaya",
+    "name_de": "Papau"
   },
   {
     "node": 4047,
     "scientific name": "Coriandrum sativum",
     "name": "coriander",
     "parent": 4046,
-    "name_es": "cilantro"
+    "name_es": "cilantro",
+    "name_de": "Koriander"
   },
   {
     "node": 4054,
     "scientific name": "Panax ginseng",
     "name": "ginseng",
     "parent": 4053,
-    "name_es": "ginseng"
+    "name_es": "ginseng",
+    "name_de": "Ginseng"
   },
   {
     "node": 271192,
     "scientific name": "Pimpinella anisum",
     "name": "anise",
     "parent": 40958,
-    "name_es": "an\u00eds"
+    "name_es": "anís",
+    "name_de": "Anis"
   },
   {
     "node": 4298,
     "scientific name": "Ilex aquifolium",
     "name": "holly",
     "parent": 4295,
-    "name_es": "acebo"
+    "name_es": "acebo",
+    "name_de": "Stechpalme"
   },
   {
     "node": 155124,
     "scientific name": "Aspalathus linearis",
     "name": "rooibos",
     "parent": 70004,
-    "name_es": "rooibos"
+    "name_es": "rooibos",
+    "name_de": "Rooibos"
   },
   {
     "node": 4103,
     "scientific name": "Petunia integrifolia",
     "name": "petunia",
     "parent": 4101,
-    "name_es": "petunia"
+    "name_es": "petunia",
+    "name_de": "Petunie"
   },
   {
     "node": 3972,
     "scientific name": "Viscum album",
     "name": "mistletoe",
     "parent": 3971,
-    "name_es": "mu\u00e9rdago"
+    "name_es": "muérdago",
+    "name_de": "Mistel"
   },
   {
     "node": 289672,
     "scientific name": "Erythroxylum coca",
     "name": "coca",
     "parent": 13511,
-    "name_es": "coca"
+    "name_es": "coca",
+    "name_de": "Kokastrauch"
   },
   {
     "node": 3988,
     "scientific name": "Ricinus communis",
     "name": "ricin",
     "parent": 3987,
-    "name_es": "ricina"
+    "name_es": "ricina",
+    "name_de": "Rizinus"
   },
   {
     "node": 379952,
     "scientific name": "Geranium phaeum",
     "name": "geranium",
     "parent": 4028,
-    "name_es": "geranio"
+    "name_es": "geranio",
+    "name_de": "Storchschnabel"
   },
   {
     "node": 3489,
     "scientific name": "Artocarpus heterophyllus",
     "name": "jackfruit",
     "parent": 3488,
-    "name_es": "jackfruit"
+    "name_es": "jackfruit",
+    "name_de": "Jackfrucht"
   },
   {
     "node": 3501,
     "scientific name": "Urtica dioica",
     "name": "nettle",
     "parent": 3500,
-    "name_es": "ortiga"
+    "name_es": "ortiga",
+    "name_de": "Brennnessel"
   },
   {
     "node": 38868,
     "scientific name": "Salvia officinalis",
     "name": "sage",
     "parent": 2291027,
-    "name_es": "salvia"
+    "name_es": "salvia",
+    "name_de": "Salbei"
   },
   {
     "node": 39367,
     "scientific name": "Salvia rosmarinus",
     "name": "rosemary",
     "parent": 39177,
-    "name_es": "romero"
+    "name_es": "romero",
+    "name_de": "Rosmarin"
   }
 ]


### PR DESCRIPTION
This adds German translations. This does not yet include aliases (e.g. instead of "Hausratte" one could write "Ratte"). Also, the R script I used to update the json file from a CSV table of translations replaced Unicode escapes `\u....` by the respective characters. But as far as I can see, some languages use the escapes while others use the respective unicode characters in the JSON file so I figured it does not make a difference as the files are unicode-encoded already. Otherwise, it could be easily changed using e.g. the R package [uniscape](https://github.com/mvkorpel/uniscape)