### PR TITLE
Correct pt translation of Spisula solidissima

### DIFF
--- a/Species Lists/animals.json
+++ b/Species Lists/animals.json
@@ -2536,7 +2536,7 @@
     "name_fr": "palourde",
     "name_hu": "tengeri kagyló",
     "name_it": "vongola",
-    "name_pt": "molusco do mar",
+    "name_pt": "Amêijoa do Atlântico",
     "name_ca": "cloïssa de l'atlàntic",
     "name_ko": "조개",
     "name_de": "Meerklaffmuschel",


### PR DESCRIPTION
The current one is a direct translation probably made by google translate. The species name is 'amêijoa do atlântico' as you can see in the translated wikipedia page: https://en-wikipedia-org.translate.goog/wiki/Atlantic_surf_clam?_x_tr_sl=en&_x_tr_tl=pt&_x_tr_hl=pt&_x_tr_pto=tc

