### PR TITLE
Fix french name for Coffea arabica

### DIFF
--- a/Species Lists/plants.json
+++ b/Species Lists/plants.json
@@ -1577,7 +1577,7 @@
     "name": "coffee",
     "parentId": 13442,
     "name_es": "café",
-    "name_fr": "caffé",
+    "name_fr": "café",
     "name_de": "Kaffee",
     "name_tr": "kahve",
     "name_cs": "kávovník arabský",


### PR DESCRIPTION
Hello, 
This PR is to fix a small typo in the french name for Coffea arabica which should be "café" and not "caffé".