### PR TITLE
Hungarian alt_names

### DIFF
--- a/Species Lists/alt_names.json
+++ b/Species Lists/alt_names.json
@@ -1097,6 +1097,7 @@
   { "language": "hu", "name": "muréna", "alts": ["muréna angolna"] },
   { "language": "hu", "name": "laposhal", "alts": ["lepényhal"] },
   { "language": "hu", "name": "álkaszáspók", "alts": ["pincepók"] },
+  { "language": "hu", "name": "pelikán", "alts": ["gödény"] },
   { "language": "hu", "name": "sárgabarack", "alts": ["kajszibarack"] },
   { "language": "hu", "name": "hajdina", "alts": ["pohánka", "tatárbúza"] },
   { "language": "hu", "name": "manióka", "alts": ["tápióka", "kasszáva"] },


### PR DESCRIPTION
Added the alternative name "gödény" to pelikán.